### PR TITLE
Fix gcc warning with -Wextra.

### DIFF
--- a/include/boost/ptr_container/detail/map_iterator.hpp
+++ b/include/boost/ptr_container/detail/map_iterator.hpp
@@ -48,8 +48,8 @@ namespace boost
             ref_pair( const RP* rp )
             : first(rp->first), second(rp->second)
             { }
-            
-            const ref_pair* const operator->() const
+
+            const ref_pair* operator->() const
             {
                 return this;
             }


### PR DESCRIPTION
Hi,
gcc is emitting a warning in the file map_iterator.hpp when using -Wextra:

include/boost/ptr_container/detail/map_iterator.hpp:52:48: error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]
             const ref_pair\* const operator->() const
                                                ^

Indeed const on the pointer itself is not needed.

Ok for the trunk ?

Cheers,
Romain
