### PR TITLE
Conditionally provide interfaces based on deprecated/removed std::aut…

### DIFF
--- a/include/boost/ptr_container/detail/associative_ptr_container.hpp
+++ b/include/boost/ptr_container/detail/associative_ptr_container.hpp
@@ -103,10 +103,18 @@ namespace ptr_container_detail
          : base_type( first, last, hash, pred, a )
         { }
         
+#ifndef BOOST_NO_AUTO_PTR        
         template< class PtrContainer >
         explicit associative_ptr_container( std::auto_ptr<PtrContainer> r )
          : base_type( r )
         { }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class PtrContainer >
+        explicit associative_ptr_container( std::unique_ptr<PtrContainer> r )
+         : base_type( std::move( r ) )
+        { }
+#endif
 
         associative_ptr_container( const associative_ptr_container& r )
          : base_type( r.begin(), r.end(), container_type() )
@@ -117,12 +125,22 @@ namespace ptr_container_detail
          : base_type( r.begin(), r.end(), container_type() )
         { }
         
+#ifndef BOOST_NO_AUTO_PTR        
         template< class PtrContainer >
         associative_ptr_container& operator=( std::auto_ptr<PtrContainer> r ) // nothrow
         {
            base_type::operator=( r );
            return *this;
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class PtrContainer >
+        associative_ptr_container& operator=( std::unique_ptr<PtrContainer> r ) // nothrow
+        {
+           base_type::operator=( std::move( r ) );
+           return *this;
+        }
+#endif
         
         associative_ptr_container& operator=( associative_ptr_container r ) // strong
         {

--- a/include/boost/ptr_container/detail/reversible_ptr_container.hpp
+++ b/include/boost/ptr_container/detail/reversible_ptr_container.hpp
@@ -345,12 +345,21 @@ namespace ptr_container_detail
         explicit reversible_ptr_container( const allocator_type& a ) 
          : c_( a )
         { }
-        
+
+#ifndef BOOST_NO_AUTO_PTR        
         template< class PtrContainer >
         explicit reversible_ptr_container( std::auto_ptr<PtrContainer> clone )                
         { 
             swap( *clone ); 
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class PtrContainer >
+        explicit reversible_ptr_container( std::unique_ptr<PtrContainer> clone )                
+        { 
+            swap( *clone ); 
+        }
+#endif
 
         reversible_ptr_container( const reversible_ptr_container& r ) 
         {
@@ -363,12 +372,22 @@ namespace ptr_container_detail
             constructor_impl( r.begin(), r.end(), std::forward_iterator_tag() ); 
         }
 
+#ifndef BOOST_NO_AUTO_PTR        
         template< class PtrContainer >
         reversible_ptr_container& operator=( std::auto_ptr<PtrContainer> clone ) // nothrow
         {
             swap( *clone );
             return *this;
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class PtrContainer >
+        reversible_ptr_container& operator=( std::unique_ptr<PtrContainer> clone ) // nothrow
+        {
+            swap( *clone );
+            return *this;
+        }
+#endif
 
         reversible_ptr_container& operator=( reversible_ptr_container r ) // strong 
         {
@@ -588,11 +607,20 @@ namespace ptr_container_detail
             return res;
         }
 
+#ifndef BOOST_NO_AUTO_PTR        
         template< class U >
         iterator insert( iterator before, std::auto_ptr<U> x )
         {
             return insert( before, x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        iterator insert( iterator before, std::unique_ptr<U> x )
+        {
+            return insert( before, x.release() );
+        }
+#endif
 
         iterator erase( iterator x ) // nothrow
         {
@@ -650,11 +678,20 @@ namespace ptr_container_detail
             return boost::ptr_container_detail::move( old );
         }
 
+#ifndef BOOST_NO_AUTO_PTR        
         template< class U >
         auto_type replace( iterator where, std::auto_ptr<U> x )
         {
             return replace( where, x.release() ); 
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        auto_type replace( iterator where, std::unique_ptr<U> x )
+        {
+            return replace( where, x.release() ); 
+        }
+#endif
 
         auto_type replace( size_type idx, Ty_* x ) // strong
         {
@@ -669,11 +706,20 @@ namespace ptr_container_detail
             return boost::ptr_container_detail::move( old );
         } 
 
+#ifndef BOOST_NO_AUTO_PTR        
         template< class U >
         auto_type replace( size_type idx, std::auto_ptr<U> x )
         {
             return replace( idx, x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        auto_type replace( size_type idx, std::unique_ptr<U> x )
+        {
+            return replace( idx, x.release() );
+        }
+#endif
                 
     }; // 'reversible_ptr_container'
 
@@ -689,12 +735,9 @@ namespace ptr_container_detail
 #define BOOST_PTR_CONTAINER_DEFINE_RELEASE( base_type ) \
     using base_type::release;
 #endif
-    
-    //
-    // two-phase lookup of template functions 
-    // is buggy on most compilers, so we use a macro instead
-    //
-#define BOOST_PTR_CONTAINER_DEFINE_RELEASE_AND_CLONE( PC, base_type, this_type ) \
+
+#ifndef BOOST_NO_AUTO_PTR        
+#define BOOST_PTR_CONTAINER_COPY_AND_ASSIGN_AUTO( PC, base_type, this_type ) \
     explicit PC( std::auto_ptr<this_type> r )       \
     : base_type ( r ) { }                           \
                                                     \
@@ -702,20 +745,64 @@ namespace ptr_container_detail
     {                                               \
         base_type::operator=( r );                  \
         return *this;                               \
-    }                                               \
+    }
+#else
+#define BOOST_PTR_CONTAINER_COPY_AND_ASSIGN_AUTO( PC, base_type, this_type )
+#endif
+
+#ifndef BOOST_NO_CXX11_SMART_PTR
+#define BOOST_PTR_CONTAINER_COPY_AND_ASSIGN_UNIQUE( PC, base_type, this_type ) \
+    explicit PC( std::unique_ptr<this_type> r )     \
+    : base_type ( std::move( r ) ) { }              \
                                                     \
+    PC& operator=( std::unique_ptr<this_type> r )   \
+    {                                               \
+        base_type::operator=( std::move( r ) );     \
+        return *this;                               \
+    }
+#else
+#define BOOST_PTR_CONTAINER_COPY_AND_ASSIGN_UNIQUE( PC, base_type, this_type )
+#endif
+
+#ifndef BOOST_NO_AUTO_PTR        
+#define BOOST_PTR_CONTAINER_RELEASE_AND_CLONE( this_type ) \
     std::auto_ptr<this_type> release()              \
     {                                               \
       std::auto_ptr<this_type> ptr( new this_type );\
       this->swap( *ptr );                           \
       return ptr;                                   \
     }                                               \
-    BOOST_PTR_CONTAINER_DEFINE_RELEASE( base_type ) \
                                                     \
     std::auto_ptr<this_type> clone() const          \
     {                                               \
        return std::auto_ptr<this_type>( new this_type( this->begin(), this->end() ) ); \
     }
+#elif !defined( BOOST_NO_CXX11_SMART_PTR )
+#define BOOST_PTR_CONTAINER_RELEASE_AND_CLONE( this_type ) \
+    std::unique_ptr<this_type> release()              \
+    {                                                 \
+      std::unique_ptr<this_type> ptr( new this_type );\
+      this->swap( *ptr );                             \
+      return ptr;                                     \
+    }                                                 \
+                                                      \
+    std::unique_ptr<this_type> clone() const          \
+    {                                                 \
+       return std::unique_ptr<this_type>( new this_type( this->begin(), this->end() ) ); \
+    }
+#else
+#define BOOST_PTR_CONTAINER_RELEASE_AND_CLONE( this_type )
+#endif
+    
+    //
+    // two-phase lookup of template functions 
+    // is buggy on most compilers, so we use a macro instead
+    //
+#define BOOST_PTR_CONTAINER_DEFINE_RELEASE_AND_CLONE( PC, base_type, this_type )  \
+    BOOST_PTR_CONTAINER_COPY_AND_ASSIGN_AUTO( PC, base_type, this_type )   \
+    BOOST_PTR_CONTAINER_COPY_AND_ASSIGN_UNIQUE( PC, base_type, this_type ) \
+    BOOST_PTR_CONTAINER_RELEASE_AND_CLONE( this_type )                     \
+    BOOST_PTR_CONTAINER_DEFINE_RELEASE( base_type )
 
 #define BOOST_PTR_CONTAINER_DEFINE_COPY_CONSTRUCTORS( PC, base_type ) \
                                                                       \

--- a/include/boost/ptr_container/ptr_circular_buffer.hpp
+++ b/include/boost/ptr_container/ptr_circular_buffer.hpp
@@ -294,11 +294,20 @@ namespace boost
             this->base().push_back( ptr );           
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         void push_back( std::auto_ptr<U> ptr ) // nothrow
         {
             push_back( ptr.release() ); 
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        void push_back( std::unique_ptr<U> ptr ) // nothrow
+        {
+            push_back( ptr.release() ); 
+        }
+#endif
 
         void push_front( value_type ptr ) // nothrow
         {
@@ -311,11 +320,20 @@ namespace boost
             this->base().push_front( ptr );            
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         void push_front( std::auto_ptr<U> ptr ) // nothrow
         {
             push_front( ptr.release() ); 
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        void push_front( std::unique_ptr<U> ptr ) // nothrow
+        {
+            push_front( ptr.release() ); 
+        }
+#endif
 
         iterator insert( iterator pos, value_type ptr ) // nothrow
         {
@@ -335,11 +353,20 @@ namespace boost
             return this->base().insert( pos.base(), ptr );
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         iterator insert( iterator pos, std::auto_ptr<U> ptr ) // nothrow
         {
             return insert( pos, ptr.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        iterator insert( iterator pos, std::unique_ptr<U> ptr ) // nothrow
+        {
+            return insert( pos, ptr.release() );
+        }
+#endif
 
         template< class InputIterator >
         void insert( iterator pos, InputIterator first, InputIterator last ) // basic
@@ -378,11 +405,20 @@ namespace boost
             return this->base().rinsert( pos.base(), ptr );
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         iterator rinsert( iterator pos, std::auto_ptr<U> ptr ) // nothrow
         {
             return rinsert( pos, ptr.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        iterator rinsert( iterator pos, std::unique_ptr<U> ptr ) // nothrow
+        {
+            return rinsert( pos, ptr.release() );
+        }
+#endif
 
  
         template< class InputIterator >

--- a/include/boost/ptr_container/ptr_inserter.hpp
+++ b/include/boost/ptr_container/ptr_inserter.hpp
@@ -71,6 +71,7 @@ namespace ptr_container
             return *this;
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class T >
         ptr_back_insert_iterator& 
         operator=( std::auto_ptr<T> r )
@@ -78,6 +79,16 @@ namespace ptr_container
             container->push_back( r );
             return *this;
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class T >
+        ptr_back_insert_iterator& 
+        operator=( std::unique_ptr<T> r )
+        {
+            container->push_back( std::move( r ) );
+            return *this;
+        }
+#endif
 
         ptr_back_insert_iterator& 
         operator=( typename PtrContainer::const_reference r )
@@ -128,6 +139,7 @@ namespace ptr_container
             return *this;
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class T >
         ptr_front_insert_iterator& 
         operator=( std::auto_ptr<T> r )
@@ -135,6 +147,16 @@ namespace ptr_container
             container->push_front( r );
             return *this;
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class T >
+        ptr_front_insert_iterator& 
+        operator=( std::unique_ptr<T> r )
+        {
+            container->push_front( std::move( r ) );
+            return *this;
+        }
+#endif
         
         ptr_front_insert_iterator& 
         operator=( typename PtrContainer::const_reference r )
@@ -187,6 +209,7 @@ namespace ptr_container
             return *this;
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class T >
         ptr_insert_iterator& 
         operator=( std::auto_ptr<T> r )
@@ -194,6 +217,16 @@ namespace ptr_container
             iter = container->insert( iter, r );
             return *this;
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class T >
+        ptr_insert_iterator& 
+        operator=( std::unique_ptr<T> r )
+        {
+            iter = container->insert( iter, std::move( r ) );
+            return *this;
+        }
+#endif
         
         ptr_insert_iterator& 
         operator=( typename PtrContainer::const_reference r )

--- a/include/boost/ptr_container/ptr_map_adapter.hpp
+++ b/include/boost/ptr_container/ptr_map_adapter.hpp
@@ -259,6 +259,7 @@ namespace ptr_container_detail
          : base_type( first, last, hash, pred, a )
         { }
                 
+#ifndef BOOST_NO_AUTO_PTR
         template< class PtrContainer >
         explicit ptr_map_adapter_base( std::auto_ptr<PtrContainer> clone ) 
         : base_type( clone )
@@ -270,6 +271,20 @@ namespace ptr_container_detail
             base_type::operator=( clone );
             return *this;
         }        
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class PtrContainer >
+        explicit ptr_map_adapter_base( std::unique_ptr<PtrContainer> clone ) 
+        : base_type( std::move( clone ) )
+        { }
+        
+        template< typename PtrContainer >
+        ptr_map_adapter_base& operator=( std::unique_ptr<PtrContainer> clone )    
+        {
+            base_type::operator=( std::move( clone ) );
+            return *this;
+        }        
+#endif
 
         iterator find( const key_type& x )                                                
         {                                                                            
@@ -353,11 +368,20 @@ namespace ptr_container_detail
             return boost::ptr_container::move( old );
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         auto_type replace( iterator where, std::auto_ptr<U> x )
         {
             return replace( where, x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        auto_type replace( iterator where, std::unique_ptr<U> x )
+        {
+            return replace( where, x.release() );
+        }
+#endif
 
     protected:
         size_type bucket( const key_type& key ) const
@@ -488,9 +512,16 @@ namespace ptr_container_detail
             map_basic_clone_and_insert( r.begin(), r.end() );      
         }
         
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         ptr_map_adapter( std::auto_ptr<U> r ) : base_type( r )
         { }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        ptr_map_adapter( std::unique_ptr<U> r ) : base_type( std::move( r ) )
+        { }
+#endif
 
         ptr_map_adapter& operator=( ptr_map_adapter r )
         {
@@ -498,12 +529,22 @@ namespace ptr_container_detail
             return *this;
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         ptr_map_adapter& operator=( std::auto_ptr<U> r )
         {  
             base_type::operator=( r );
             return *this;
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        ptr_map_adapter& operator=( std::unique_ptr<U> r )
+        {  
+            base_type::operator=( std::move( r ) );
+            return *this;
+        }
+#endif
 
         using base_type::release;
 
@@ -552,11 +593,20 @@ namespace ptr_container_detail
             return insert_impl( key, x );
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         std::pair<iterator,bool> insert( const key_type& key, std::auto_ptr<U> x )
         {
             return insert_impl( key, x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        std::pair<iterator,bool> insert( const key_type& key, std::unique_ptr<U> x )
+        {
+            return insert_impl( key, x.release() );
+        }
+#endif
 
         template< class F, class S >
         iterator insert( iterator before, ptr_container_detail::ref_pair<F,S> p ) // strong
@@ -579,11 +629,20 @@ namespace ptr_container_detail
             return insert_impl( before, key, x );
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         iterator insert( iterator before, const key_type& key, std::auto_ptr<U> x ) // strong
         {
             return insert_impl( before, key, x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        iterator insert( iterator before, const key_type& key, std::unique_ptr<U> x ) // strong
+        {
+            return insert_impl( before, key, x.release() );
+        }
+#endif
         
         template< class PtrMapAdapter >
         bool transfer( BOOST_DEDUCED_TYPENAME PtrMapAdapter::iterator object, 
@@ -738,9 +797,16 @@ namespace ptr_container_detail
             map_basic_clone_and_insert( r.begin(), r.end() );      
         }
         
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         explicit ptr_multimap_adapter( std::auto_ptr<U> r ) : base_type( r )
         { }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        explicit ptr_multimap_adapter( std::unique_ptr<U> r ) : base_type( std::move( r ) )
+        { }
+#endif
 
         ptr_multimap_adapter& operator=( ptr_multimap_adapter r )
         {
@@ -748,12 +814,22 @@ namespace ptr_container_detail
             return *this;
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         ptr_multimap_adapter& operator=( std::auto_ptr<U> r )
         {  
             base_type::operator=( r );
             return *this;
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        ptr_multimap_adapter& operator=( std::unique_ptr<U> r )
+        {  
+            base_type::operator=( std::move( r ) );
+            return *this;
+        }
+#endif
 
         using base_type::release;
 
@@ -803,11 +879,20 @@ namespace ptr_container_detail
             return insert_impl( key, x );
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         iterator insert( const key_type& key, std::auto_ptr<U> x )
         {
             return insert_impl( key, x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        iterator insert( const key_type& key, std::unique_ptr<U> x )
+        {
+            return insert_impl( key, x.release() );
+        }
+#endif
 
         template< class F, class S >
         iterator insert( iterator before, ptr_container_detail::ref_pair<F,S> p ) // strong
@@ -824,11 +909,20 @@ namespace ptr_container_detail
             return insert_impl( before, key, x );
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         iterator insert( iterator before, const key_type& key, std::auto_ptr<U> x ) // strong
         {
             return insert_impl( before, key, x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        iterator insert( iterator before, const key_type& key, std::unique_ptr<U> x ) // strong
+        {
+            return insert_impl( before, key, x.release() );
+        }
+#endif
         
         template< class PtrMapAdapter >
         void transfer( BOOST_DEDUCED_TYPENAME PtrMapAdapter::iterator object, 

--- a/include/boost/ptr_container/ptr_sequence_adapter.hpp
+++ b/include/boost/ptr_container/ptr_sequence_adapter.hpp
@@ -219,10 +219,18 @@ namespace ptr_container_detail
           : base_type( r, tag )
         { }
         
+#ifndef BOOST_NO_AUTO_PTR
         template< class PtrContainer >
         explicit ptr_sequence_adapter( std::auto_ptr<PtrContainer> clone )
           : base_type( clone )
         { }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class PtrContainer >
+        explicit ptr_sequence_adapter( std::unique_ptr<PtrContainer> clone )
+          : base_type( std::move( clone ) )
+        { }
+#endif
 
         ptr_sequence_adapter& operator=( const ptr_sequence_adapter r )
         {
@@ -230,12 +238,22 @@ namespace ptr_container_detail
             return *this; 
         }
         
+#ifndef BOOST_NO_AUTO_PTR
         template< class PtrContainer >
         ptr_sequence_adapter& operator=( std::auto_ptr<PtrContainer> clone )    
         {
             base_type::operator=( clone );
             return *this;
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class PtrContainer >
+        ptr_sequence_adapter& operator=( std::unique_ptr<PtrContainer> clone )    
+        {
+            base_type::operator=( std::move( clone ) );
+            return *this;
+        }
+#endif
 
         /////////////////////////////////////////////////////////////
         // modifiers
@@ -249,11 +267,20 @@ namespace ptr_container_detail
             ptr.release();                // nothrow
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         void push_back( std::auto_ptr<U> x )
         {
             push_back( x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        void push_back( std::unique_ptr<U> x )
+        {
+            push_back( x.release() );
+        }
+#endif
         
         void push_front( value_type x )                
         {
@@ -263,11 +290,20 @@ namespace ptr_container_detail
             ptr.release();                // nothrow
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         void push_front( std::auto_ptr<U> x )
         {
             push_front( x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        void push_front( std::unique_ptr<U> x )
+        {
+            push_front( x.release() );
+        }
+#endif
 
         auto_type pop_back()
         {

--- a/include/boost/ptr_container/ptr_set_adapter.hpp
+++ b/include/boost/ptr_container/ptr_set_adapter.hpp
@@ -182,10 +182,18 @@ namespace ptr_container_detail
           : base_type( r )
         { }
                 
+#ifndef BOOST_NO_AUTO_PTR
         template< class PtrContainer >
         explicit ptr_set_adapter_base( std::auto_ptr<PtrContainer> clone )
          : base_type( clone )
         { }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class PtrContainer >
+        explicit ptr_set_adapter_base( std::unique_ptr<PtrContainer> clone )
+         : base_type( std::move( clone ) )
+        { }
+#endif
         
         ptr_set_adapter_base& operator=( ptr_set_adapter_base r ) 
         {
@@ -193,12 +201,22 @@ namespace ptr_container_detail
             return *this;
         }
         
+#ifndef BOOST_NO_AUTO_PTR
         template< typename PtrContainer >
         ptr_set_adapter_base& operator=( std::auto_ptr<PtrContainer> clone )    
         {
             base_type::operator=( clone );
             return *this;
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< typename PtrContainer >
+        ptr_set_adapter_base& operator=( std::unique_ptr<PtrContainer> clone )    
+        {
+            base_type::operator=( std::move( clone ) );
+            return *this;
+        }
+#endif
 
         using base_type::erase;
         
@@ -393,10 +411,18 @@ namespace ptr_container_detail
           : base_type( r )
         { }
         
+#ifndef BOOST_NO_AUTO_PTR
         template< class PtrContainer >
         explicit ptr_set_adapter( std::auto_ptr<PtrContainer> clone )
          : base_type( clone )
         { }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class PtrContainer >
+        explicit ptr_set_adapter( std::unique_ptr<PtrContainer> clone )
+         : base_type( std::move( clone ) )
+        { }
+#endif
 
         template< class U, class Set, class CA, bool b >
         ptr_set_adapter& operator=( const ptr_set_adapter<U,Set,CA,b>& r ) 
@@ -405,11 +431,20 @@ namespace ptr_container_detail
             return *this;
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class T >
         void operator=( std::auto_ptr<T> r ) 
         {
             base_type::operator=( r );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class T >
+        void operator=( std::unique_ptr<T> r ) 
+        {
+            base_type::operator=( std::move( r ) );
+        }
+#endif
 
         std::pair<iterator,bool> insert( key_type* x ) // strong                      
         {       
@@ -423,11 +458,20 @@ namespace ptr_container_detail
             return std::make_pair( iterator( res.first ), res.second );     
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         std::pair<iterator,bool> insert( std::auto_ptr<U> x )
         {
             return insert( x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        std::pair<iterator,bool> insert( std::unique_ptr<U> x )
+        {
+            return insert( x.release() );
+        }
+#endif
 
         
         iterator insert( iterator where, key_type* x ) // strong
@@ -442,11 +486,20 @@ namespace ptr_container_detail
             return iterator( res);
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         iterator insert( iterator where, std::auto_ptr<U> x )
         {
             return insert( where, x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        iterator insert( iterator where, std::unique_ptr<U> x )
+        {
+            return insert( where, x.release() );
+        }
+#endif
         
         template< typename InputIterator >
         void insert( InputIterator first, InputIterator last ) // basic
@@ -593,10 +646,18 @@ namespace ptr_container_detail
           : base_type( r )
         { }
         
+#ifndef BOOST_NO_AUTO_PTR
         template< class PtrContainer >
         explicit ptr_multiset_adapter( std::auto_ptr<PtrContainer> clone )
          : base_type( clone )
         { }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class PtrContainer >
+        explicit ptr_multiset_adapter( std::unique_ptr<PtrContainer> clone )
+         : base_type( std::move( clone ) )
+        { }
+#endif
 
         template< class U, class Set, class CA, bool b >
         ptr_multiset_adapter& operator=( const ptr_multiset_adapter<U,Set,CA,b>& r ) 
@@ -605,22 +666,40 @@ namespace ptr_container_detail
             return *this;
         }
         
+#ifndef BOOST_NO_AUTO_PTR
         template< class T >
         void operator=( std::auto_ptr<T> r ) 
         {
             base_type::operator=( r ); 
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class T >
+        void operator=( std::unique_ptr<T> r ) 
+        {
+            base_type::operator=( std::move( r ) ); 
+        }
+#endif
 
         iterator insert( iterator before, key_type* x ) // strong  
         {
             return base_type::insert( before, x ); 
         } 
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         iterator insert( iterator before, std::auto_ptr<U> x )
         {
             return insert( before, x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        iterator insert( iterator before, std::unique_ptr<U> x )
+        {
+            return insert( before, x.release() );
+        }
+#endif
     
         iterator insert( key_type* x ) // strong                                      
         {   
@@ -633,11 +712,20 @@ namespace ptr_container_detail
             return iterator( res );                                             
         }
 
+#ifndef BOOST_NO_AUTO_PTR
         template< class U >
         iterator insert( std::auto_ptr<U> x )
         {
             return insert( x.release() );
         }
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        template< class U >
+        iterator insert( std::unique_ptr<U> x )
+        {
+            return insert( x.release() );
+        }
+#endif
     
         template< typename InputIterator >
         void insert( InputIterator first, InputIterator last ) // basic

--- a/test/associative_test_data.hpp
+++ b/test/associative_test_data.hpp
@@ -100,10 +100,17 @@ void ptr_set_test()
     
     T* t = new T;
     c.insert( c.end(), t );    
-    c.insert( c.end(), std::auto_ptr<T>( new T ) );
     c.insert( new T ); 
+#ifndef BOOST_NO_AUTO_PTR        
+    c.insert( c.end(), std::auto_ptr<T>( new T ) );
     std::auto_ptr<T> ap( new T );
     c.insert( ap );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    c.insert( c.end(), std::unique_ptr<T>( new T ) );
+    std::unique_ptr<T> up( new T );
+    c.insert( std::move( up ) );
+#endif
     c3.insert( c.begin(), c.end() ); 
     c.erase( c.begin() );
     c3.erase( c3.begin(), c3.end() );
@@ -130,7 +137,11 @@ void ptr_set_test()
              
     c.insert( c.end(), new T );
     typename C::auto_type ptr2  = c.release( c.begin() );
-    std::auto_ptr<C> ap2         = c.release();
+#ifndef BOOST_NO_AUTO_PTR
+    std::auto_ptr<C> ap2        = c.release();
+#else
+    std::unique_ptr<C> up2      = c.release();
+#endif
     c                           = c2.clone();
     BOOST_TEST_MESSAGE( "finished release/clone test" ); 
 

--- a/test/ptr_array.cpp
+++ b/test/ptr_array.cpp
@@ -89,7 +89,12 @@ void test_array()
     ptr_array<int,10> vec;
     BOOST_CHECK_THROW( vec.at(10), bad_ptr_container_operation );
     BOOST_CHECK_THROW( (vec.replace(10u, new int(0))), bad_ptr_container_operation );
+#ifndef BOOST_NO_AUTO_PTR
     BOOST_CHECK_THROW( (vec.replace(10u, std::auto_ptr<int>(new int(0)))), bad_ptr_container_operation ); 
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    BOOST_CHECK_THROW( (vec.replace(10u, std::unique_ptr<int>(new int(0)))), bad_ptr_container_operation ); 
+#endif
     BOOST_CHECK_THROW( (vec.replace(0u, 0)), bad_ptr_container_operation ); 
 
     ptr_array<Derived_class,2> derived;
@@ -112,7 +117,12 @@ void test_array_interface()
     c.replace( 0, new T );
     c.replace( 1, new B );
     c.replace( 9, new T );
+#ifndef BOOST_NO_AUTO_PTR
     c.replace( 0, std::auto_ptr<T>( new T ) );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    c.replace( 0, std::unique_ptr<T>( new T ) );
+#endif
     const C c2( c.clone() );
     
     BOOST_DEDUCED_TYPENAME C::iterator i                  = c.begin();

--- a/test/ptr_deque.cpp
+++ b/test/ptr_deque.cpp
@@ -37,9 +37,17 @@ void test_ptr_deque()
     random_access_algorithms_test< ptr_deque<int> >();
     ptr_deque<int> di;
     di.push_front( new int(0) );
-    BOOST_CHECK_EQUAL( di.size(), 1u );
+    std::size_t size = 1u;
+    BOOST_CHECK_EQUAL( di.size(), size );
+#ifndef BOOST_NO_AUTO_PTR
     di.push_front( std::auto_ptr<int>( new int(1) ) );
-    BOOST_CHECK_EQUAL( di.size(), 2u ); 
+    ++size;
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    di.push_front( std::unique_ptr<int>( new int(2) ) );
+    ++size;
+#endif
+    BOOST_CHECK_EQUAL( di.size(), size );
 }
 
 using boost::unit_test::test_suite;

--- a/test/ptr_list.cpp
+++ b/test/ptr_list.cpp
@@ -44,7 +44,12 @@ void test_list()
     list.push_back( new int(2) );
     list.push_back( new int(1) );
     list.push_front( new int(3) );
+#ifndef BOOST_NO_AUTO_PTR
     list.push_front( std::auto_ptr<int>( new int(42) ) );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    list.push_front( std::unique_ptr<int>( new int(43) ) );
+#endif
     list.reverse();
 }
 

--- a/test/ptr_map.cpp
+++ b/test/ptr_map.cpp
@@ -142,9 +142,18 @@ void ptr_map_test()
     a_key = get_next_key( a_key );
     c.insert( a_key, new T );
     a_key = get_next_key( a_key );
+#ifndef BOOST_NO_AUTO_PTR
     c.insert( a_key, std::auto_ptr<T>( new T ) );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    c.insert( a_key, std::unique_ptr<T>( new T ) );
+#endif
     typename C::auto_type ptr2  = c.release( c.begin() );
+#ifndef BOOST_NO_AUTO_PTR
     std::auto_ptr<C> ap         = c.release();
+#else
+    std::unique_ptr<C> up       = c.release();
+#endif
     c                           = c2.clone();
     BOOST_TEST_MESSAGE( "finished release/clone test" );
 
@@ -172,7 +181,12 @@ void ptr_map_test()
 
     BOOST_CHECK( !c3.empty() );
     c3.replace( c3.begin(), new T );
+#ifndef BOOST_NO_AUTO_PTR
     c3.replace( c3.begin(), std::auto_ptr<T>( new T ) );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    c3.replace( c3.begin(), std::unique_ptr<T>( new T ) );
+#endif
     BOOST_TEST_MESSAGE( "finished set/map interface test" );
 
     // @todo: make macro with algorithms so that the right erase() is called.

--- a/test/ptr_map_adapter.cpp
+++ b/test/ptr_map_adapter.cpp
@@ -34,7 +34,12 @@ void test_ptr_map_adapter()
     
     ptr_map<string,int> m;
     m.insert( joe, new int( 4 ) );
+#ifndef BOOST_NO_AUTO_PTR
     m.insert( brian, std::auto_ptr<int>( new int( 6 ) ) );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    m.insert( brian, std::unique_ptr<int>( new int( 6 ) ) );
+#endif
     m[ joe ]   += 56;
     m[ brian ] += 10;
 

--- a/test/ptr_set.cpp
+++ b/test/ptr_set.cpp
@@ -84,10 +84,21 @@ void test_set()
 
     BOOST_CHECK_THROW( set.insert( 0 ), bad_ptr_container_operation );
     set.insert( new int(0) );
+#ifndef BOOST_NO_AUTO_PTR
     std::auto_ptr<int> ap( new int(1) );
     set.insert( ap );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    std::unique_ptr<int> up( new int(2) );
+    set.insert( std::move( up ) );
+#endif
     BOOST_CHECK_THROW( (set.replace(set.begin(), 0 )), bad_ptr_container_operation );
+#ifndef BOOST_NO_AUTO_PTR
     BOOST_CHECK_THROW( (set.replace(set.begin(), std::auto_ptr<int>(0) )), bad_ptr_container_operation );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    BOOST_CHECK_THROW( (set.replace(set.begin(), std::unique_ptr<int>(nullptr) )), bad_ptr_container_operation );
+#endif
 
     test_erase< ptr_set<Base> >();
     test_erase< ptr_multiset<Base> >();

--- a/test/ptr_unordered_map.cpp
+++ b/test/ptr_unordered_map.cpp
@@ -146,9 +146,18 @@ void ptr_map_test()
     a_key = get_next_key( a_key );
     c.insert( a_key, new T );
     a_key = get_next_key( a_key );
+#ifndef BOOST_NO_AUTO_PTR
     c.insert( a_key, std::auto_ptr<T>( new T ) );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    c.insert( a_key, std::unique_ptr<T>( new T ) );
+#endif
     typename C::auto_type ptr2  = c.release( c.begin() );
+#ifndef BOOST_NO_AUTO_PTR
     std::auto_ptr<C> ap         = c.release();
+#else
+    std::unique_ptr<C> up       = c.release();
+#endif
     c                           = c2.clone();
     BOOST_TEST_MESSAGE( "finished release/clone test" );
 
@@ -176,7 +185,12 @@ void ptr_map_test()
 
     BOOST_CHECK( !c3.empty() );
     c3.replace( c3.begin(), new T );
+#ifndef BOOST_NO_AUTO_PTR
     c3.replace( c3.begin(), std::auto_ptr<T>( new T ) );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    c3.replace( c3.begin(), std::unique_ptr<T>( new T ) );
+#endif
     BOOST_TEST_MESSAGE( "finished set/map interface test" );
 
     // @todo: make macro with algorithms so that the right erase() is called.

--- a/test/ptr_unordered_set.cpp
+++ b/test/ptr_unordered_set.cpp
@@ -106,10 +106,21 @@ void test_set()
 
     BOOST_CHECK_THROW( set.insert( 0 ), bad_ptr_container_operation );
     set.insert( new int(0) );
+#ifndef BOOST_NO_AUTO_PTR
     std::auto_ptr<int> ap( new int(1) );
     set.insert( ap );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    std::unique_ptr<int> up( new int(2) );
+    set.insert( std::move( up ) );
+#endif
     BOOST_CHECK_THROW( (set.replace(set.begin(), 0 )), bad_ptr_container_operation );
+#ifndef BOOST_NO_AUTO_PTR
     BOOST_CHECK_THROW( (set.replace(set.begin(), std::auto_ptr<int>(0) )), bad_ptr_container_operation );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    BOOST_CHECK_THROW( (set.replace(set.begin(), std::unique_ptr<int>(nullptr) )), bad_ptr_container_operation );
+#endif
 
     test_unordered_interface< ptr_unordered_set<Base>, Derived_class >();
     test_unordered_interface< ptr_unordered_multiset<Base>, Derived_class >();

--- a/test/sequence_test_data.hpp
+++ b/test/sequence_test_data.hpp
@@ -25,7 +25,7 @@ void reversible_container_test()
     using namespace boost;
     
     BOOST_TEST_MESSAGE( "starting reversible container test" ); 
-    enum { max_cnt = 10, size = 100 };
+    enum { max_cnt = 10 };
     C  c;
     set_capacity<C>()( c );
     BOOST_CHECK( c.size() == 0 );
@@ -82,7 +82,15 @@ void reversible_container_test()
     BOOST_DEDUCED_TYPENAME C::size_type s2                = c.max_size();
     hide_warning(s2);
     c.push_back( new T );
+    std::size_t size = 2u;
+#ifndef BOOST_NO_AUTO_PTR
     c.push_back( std::auto_ptr<T>( new T ) );
+    ++size;
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    c.push_back( std::unique_ptr<T>( new T ) );
+    ++size;
+#endif
     bool b                                                = c.empty();
     BOOST_CHECK( !c.empty() );
     b                                                     = is_null( c.begin() );
@@ -98,14 +106,23 @@ void reversible_container_test()
     BOOST_TEST_MESSAGE( "finished accessors test" ); 
     
     c.push_back( new T );
-    BOOST_CHECK_EQUAL( c.size(), 4u );
+    ++size;
+    BOOST_CHECK_EQUAL( c.size(), size );
 
     c.pop_back(); 
     BOOST_CHECK( !c.empty() );
     c.insert( c.end(), new T );
+#ifndef BOOST_NO_AUTO_PTR
     std::auto_ptr<T> ap(new T);
     c.insert( c.end(), ap );
-    BOOST_CHECK_EQUAL( c.size(), 5u );
+    ++size;
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    std::unique_ptr<T> up( new T );
+    c.insert( c.end(), std::move( up ) );
+    ++size;
+#endif
+    BOOST_CHECK_EQUAL( c.size(), size );
 
 #if defined(BOOST_NO_SFINAE) || defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
 #else
@@ -136,11 +153,20 @@ void reversible_container_test()
 #else
     auto_type ptr       = c.release( c.begin() );
 #endif    
-    std::auto_ptr<C> ap2 = c.release();
+#ifndef BOOST_NO_AUTO_PTR
+    std::auto_ptr<C> ap2   = c.release();
+#else
+    std::unique_ptr<C> up2 = c.release();
+#endif
     c                   = c2.clone();
     BOOST_CHECK( !c.empty() );
     auto_type ptr2      = c.replace( c.begin(), new T );
+#ifndef BOOST_NO_AUTO_PTR
     ptr2                = c.replace( c.begin(), std::auto_ptr<T>( new T ) );
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    ptr2                = c.replace( c.begin(), std::unique_ptr<T>( new T ) );
+#endif
     BOOST_TEST_MESSAGE( "finished release/clone/replace test" ); 
                      
     c3.push_back( new T );

--- a/test/tut1.cpp
+++ b/test/tut1.cpp
@@ -141,6 +141,12 @@ class farm
     typedef boost::ptr_deque<animal> barn_type;
     barn_type                        barn;
 
+#if defined( BOOST_NO_AUTO_PTR )
+    typedef std::unique_ptr<barn_type> raii_ptr;
+#else
+    typedef std::auto_ptr<barn_type> raii_ptr;
+#endif
+
     //
     // An error type
     //
@@ -244,7 +250,7 @@ public:
     //
     // If things are bad, we might choose to sell all animals :-(
     //
-    std::auto_ptr<barn_type> sell_farm()
+    raii_ptr sell_farm()
     {
         return barn.release();
     }
@@ -254,7 +260,7 @@ public:
     // else's farm :-)
     //
 
-    void buy_farm( std::auto_ptr<barn_type> other )
+    void buy_farm( raii_ptr other )
     {
         //
         // This line inserts all the animals from 'other'

--- a/test/view_example.cpp
+++ b/test/view_example.cpp
@@ -67,8 +67,12 @@ typedef boost::ptr_vector<photon,boost::view_clone_allocator> view_type;
 //
 // Our first sort criterium
 //
-struct sort_by_color : std::binary_function<photon,photon,bool>
+struct sort_by_color
 {
+    typedef photon first_argument_type;
+    typedef photon second_argument_type;
+    typedef bool result_type;
+
     bool operator()( const photon& l, const photon& r ) const
     {
         return l.color < r.color;
@@ -78,8 +82,12 @@ struct sort_by_color : std::binary_function<photon,photon,bool>
 //
 // Our second sort criterium
 //
-struct sort_by_direction : std::binary_function<photon,photon,bool>
+struct sort_by_direction
 {
+    typedef photon first_argument_type;
+    typedef photon second_argument_type;
+    typedef bool result_type;
+
     bool operator()( const photon& l, const photon& r ) const
     {
         return l.direction < r.direction;
@@ -90,8 +98,12 @@ struct sort_by_direction : std::binary_function<photon,photon,bool>
 //
 // Our third sort criterium
 //
-struct sort_by_power : std::binary_function<photon,photon,bool>
+struct sort_by_power
 {
+    typedef photon first_argument_type;
+    typedef photon second_argument_type;
+    typedef bool result_type;
+
     bool operator()( const photon& l, const photon& r ) const
     {
         return l.power < r.power;


### PR DESCRIPTION
…o_ptr and/or std::unique_ptr, and replace C++98 function adapters by inline typedefs.

Signed-off-by: Daniela Engert <dani@ngrt.de>