### PR TITLE
Disable auto_ptr deprecation warnings on g++/clang

### DIFF
--- a/include/boost/ptr_container/detail/associative_ptr_container.hpp
+++ b/include/boost/ptr_container/detail/associative_ptr_container.hpp
@@ -18,6 +18,12 @@
 #endif
 
 #include <boost/ptr_container/detail/reversible_ptr_container.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -425,5 +431,8 @@ namespace ptr_container_detail
     
 } // namespace 'boost'
 
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/detail/ptr_container_disable_deprecated.hpp
+++ b/include/boost/ptr_container/detail/ptr_container_disable_deprecated.hpp
@@ -1,0 +1,40 @@
+#ifndef BOOST_PTR_CONTAINER_DETAIL_PTR_CONTAINER_DISABLE_DEPRECATED_HPP_INCLUDED
+#define BOOST_PTR_CONTAINER_DETAIL_PTR_CONTAINER_DISABLE_DEPRECATED_HPP_INCLUDED
+
+// MS compatible compilers support #pragma once
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+# pragma once
+#endif
+
+//
+//  boost/ptr_container/detail/ptr_container_disable_deprecated.hpp
+//
+//  Copyright 2015 Peter Dimov
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/config.hpp>
+
+#if defined( __GNUC__ ) && ( defined( __GXX_EXPERIMENTAL_CXX0X__ ) || ( __cplusplus >= 201103L ) ) && !defined(BOOST_NO_AUTO_PTR)
+
+# if defined( BOOST_GCC )
+
+#  if BOOST_GCC >= 40600
+#   define BOOST_PTR_CONTAINER_DISABLE_DEPRECATED
+#  endif
+
+# elif defined( __clang__ ) && defined( __has_warning )
+
+#  if __has_warning( "-Wdeprecated-declarations" )
+#   define BOOST_PTR_CONTAINER_DISABLE_DEPRECATED
+#  endif
+
+# endif
+
+#endif
+
+#endif // #ifndef BOOST_PTR_CONTAINER_DETAIL_PTR_CONTAINER_DISABLE_DEPRECATED_HPP_INCLUDED

--- a/include/boost/ptr_container/detail/reversible_ptr_container.hpp
+++ b/include/boost/ptr_container/detail/reversible_ptr_container.hpp
@@ -20,6 +20,7 @@
 #include <boost/ptr_container/detail/throw_exception.hpp>
 #include <boost/ptr_container/detail/scoped_deleter.hpp>
 #include <boost/ptr_container/detail/static_move_ptr.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
 #include <boost/ptr_container/exception.hpp>
 #include <boost/ptr_container/clone_allocator.hpp>
 #include <boost/ptr_container/nullable.hpp>
@@ -44,6 +45,11 @@
 #pragma warning(disable:4127)
 #pragma warning(disable:4224) // formal parameter was previously defined as a type.
 #endif  
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -848,6 +854,10 @@ namespace ptr_container_detail
     }
 
 } // namespace 'boost'  
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)  
 #pragma warning(pop)  

--- a/include/boost/ptr_container/ptr_array.hpp
+++ b/include/boost/ptr_container/ptr_array.hpp
@@ -19,6 +19,12 @@
 #include <boost/array.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/ptr_container/ptr_sequence_adapter.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -284,5 +290,9 @@ namespace boost
         l.swap(r);
     }
 }
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_circular_buffer.hpp
+++ b/include/boost/ptr_container/ptr_circular_buffer.hpp
@@ -19,6 +19,12 @@
 #include <boost/circular_buffer.hpp>
 #include <boost/ptr_container/ptr_sequence_adapter.hpp>
 #include <boost/next_prior.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -565,5 +571,9 @@ namespace boost
     }
     
 }
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_circular_buffer.hpp
+++ b/include/boost/ptr_container/ptr_circular_buffer.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/circular_buffer.hpp>
 #include <boost/ptr_container/ptr_sequence_adapter.hpp>
+#include <boost/next_prior.hpp>
 
 namespace boost
 {

--- a/include/boost/ptr_container/ptr_inserter.hpp
+++ b/include/boost/ptr_container/ptr_inserter.hpp
@@ -17,8 +17,14 @@
 #endif
 
 #include <boost/config.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
 #include <iterator>
 #include <memory>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -280,5 +286,9 @@ namespace ptr_container
     
 } // namespace 'ptr_container'
 } // namespace 'boost'
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_map_adapter.hpp
+++ b/include/boost/ptr_container/ptr_map_adapter.hpp
@@ -19,8 +19,14 @@
 #include <boost/ptr_container/detail/map_iterator.hpp>
 #include <boost/ptr_container/detail/associative_ptr_container.hpp>
 #include <boost/ptr_container/detail/meta_functions.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/range/iterator_range.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -968,5 +974,9 @@ namespace ptr_container_detail
     }
     
 } // namespace 'boost'  
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_sequence_adapter.hpp
+++ b/include/boost/ptr_container/ptr_sequence_adapter.hpp
@@ -22,6 +22,7 @@
 #include <boost/ptr_container/detail/void_ptr_iterator.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <boost/next_prior.hpp>
 
 
 namespace boost

--- a/include/boost/ptr_container/ptr_sequence_adapter.hpp
+++ b/include/boost/ptr_container/ptr_sequence_adapter.hpp
@@ -20,10 +20,15 @@
 #include <boost/ptr_container/detail/reversible_ptr_container.hpp>
 #include <boost/ptr_container/indirect_fun.hpp>
 #include <boost/ptr_container/detail/void_ptr_iterator.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/next_prior.hpp>
 
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {   
@@ -806,5 +811,9 @@ namespace ptr_container_detail
 
 
 } // namespace 'boost'  
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_set_adapter.hpp
+++ b/include/boost/ptr_container/ptr_set_adapter.hpp
@@ -19,7 +19,13 @@
 #include <boost/ptr_container/detail/associative_ptr_container.hpp>
 #include <boost/ptr_container/detail/meta_functions.hpp>
 #include <boost/ptr_container/detail/void_ptr_iterator.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
 #include <boost/range/iterator_range.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -784,5 +790,9 @@ namespace ptr_container_detail
     };
 
 } // namespace 'boost'  
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif


### PR DESCRIPTION
Hi,

By default, when you use GCC 6, there are some annoying warnings each time auto_ptr are exposed in the API (even when you don't use them). This silences this warnings. It was largely inspired from this commit https://github.com/boostorg/smart_ptr/commit/df904965833dcf1bf2eb4d7d1416369dd806e092 from @pdimov (boost/ptr_container/detail/ptr_container_disable_deprecated.hpp was almost copied as is, I even left the copyright, I hope it is OK).

Cheers,
Romain