### PR TITLE
Fix build with recent boost dependencies (boost::next not found).

### DIFF
--- a/include/boost/ptr_container/ptr_circular_buffer.hpp
+++ b/include/boost/ptr_container/ptr_circular_buffer.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/circular_buffer.hpp>
 #include <boost/ptr_container/ptr_sequence_adapter.hpp>
+#include <boost/next_prior.hpp>
 
 namespace boost
 {

--- a/include/boost/ptr_container/ptr_sequence_adapter.hpp
+++ b/include/boost/ptr_container/ptr_sequence_adapter.hpp
@@ -22,6 +22,7 @@
 #include <boost/ptr_container/detail/void_ptr_iterator.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <boost/next_prior.hpp>
 
 
 namespace boost


### PR DESCRIPTION
Hi,

This should fix the build issues found in PR #11.

Cheers,
Romain