### PR TITLE
Remove remaining deprecation warnings.

### DIFF
--- a/include/boost/ptr_container/ptr_deque.hpp
+++ b/include/boost/ptr_container/ptr_deque.hpp
@@ -18,6 +18,12 @@
 
 #include <deque>
 #include <boost/ptr_container/ptr_sequence_adapter.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -65,5 +71,9 @@ namespace boost
         l.swap(r);
     }
 }
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_list.hpp
+++ b/include/boost/ptr_container/ptr_list.hpp
@@ -17,7 +17,13 @@
 #endif
 
 #include <boost/ptr_container/ptr_sequence_adapter.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
 #include <list>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -107,5 +113,8 @@ namespace boost
     }
 }
 
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_map.hpp
+++ b/include/boost/ptr_container/ptr_map.hpp
@@ -18,6 +18,12 @@
 
 #include <map>
 #include <boost/ptr_container/ptr_map_adapter.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -163,5 +169,9 @@ namespace boost
 
 
 }
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_set.hpp
+++ b/include/boost/ptr_container/ptr_set.hpp
@@ -18,7 +18,13 @@
 
 #include <boost/ptr_container/indirect_fun.hpp>
 #include <boost/ptr_container/ptr_set_adapter.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
 #include <set>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -154,5 +160,9 @@ namespace boost
     }
 
 }
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_unordered_map.hpp
+++ b/include/boost/ptr_container/ptr_unordered_map.hpp
@@ -18,6 +18,12 @@
 
 #include <boost/unordered_map.hpp>
 #include <boost/ptr_container/ptr_map_adapter.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -247,5 +253,9 @@ namespace boost
 
 
 }
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_unordered_set.hpp
+++ b/include/boost/ptr_container/ptr_unordered_set.hpp
@@ -18,7 +18,13 @@
 
 #include <boost/ptr_container/indirect_fun.hpp>
 #include <boost/ptr_container/ptr_set_adapter.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
 #include <boost/unordered_set.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -238,5 +244,9 @@ namespace boost
     }
 
 }
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/boost/ptr_container/ptr_vector.hpp
+++ b/include/boost/ptr_container/ptr_vector.hpp
@@ -18,6 +18,12 @@
 
 #include <vector>
 #include <boost/ptr_container/ptr_sequence_adapter.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace boost
 {
@@ -73,5 +79,9 @@ namespace boost
     }
     
 }
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/test/associative_test_data.hpp
+++ b/test/associative_test_data.hpp
@@ -11,7 +11,13 @@
 
 #include "test_data.hpp"
 #include <boost/ptr_container/exception.hpp>
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
 #include <boost/range/sub_range.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 template< typename C, typename B, typename T, bool Ordered >
 void ptr_set_test();
@@ -200,3 +206,6 @@ void ptr_set_test()
     
 }
 
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif

--- a/test/sequence_test_data.hpp
+++ b/test/sequence_test_data.hpp
@@ -10,8 +10,14 @@
 //
 
 #include "test_data.hpp"
+#include <boost/ptr_container/detail/ptr_container_disable_deprecated.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/bind.hpp>
+
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 template< typename C, typename B, typename T >
 void reversible_container_test();
@@ -325,3 +331,6 @@ void random_access_algorithms_test()
     BOOST_TEST_MESSAGE( "finished random accessors algorithms test" );
 }
 
+#if defined(BOOST_PTR_CONTAINER_DISABLE_DEPRECATED)
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Work in progress: I will grep all deprecation warning from the travis output that are emitted directly by the the public includes, not the ones from the test themselves.