### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/ptr_container/detail/reversible_ptr_container.hpp
+++ b/include/boost/ptr_container/detail/reversible_ptr_container.hpp
@@ -410,7 +410,7 @@ namespace ptr_container_detail
           : c_( a )
         { 
             constructor_impl( first, last, 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #else
                               BOOST_DEDUCED_TYPENAME
 #endif                              
@@ -440,7 +440,7 @@ namespace ptr_container_detail
           : c_( n )
         {
             constructor_impl( first, last, 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #else
                               BOOST_DEDUCED_TYPENAME
 #endif                              
@@ -730,7 +730,7 @@ namespace ptr_container_detail
     }; // 'reversible_ptr_container'
 
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))    
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))    
 #define BOOST_PTR_CONTAINER_DEFINE_RELEASE( base_type ) \
     typename base_type::auto_type                   \
     release( typename base_type::iterator i )       \

--- a/include/boost/ptr_container/detail/static_move_ptr.hpp
+++ b/include/boost/ptr_container/detail/static_move_ptr.hpp
@@ -65,7 +65,7 @@ public:
             const_cast<static_move_ptr&>(p).release();
         }
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))    
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))    
     static_move_ptr( const move_ptrs::move_source<static_move_ptr<T,Deleter> >& src )
 #else
     static_move_ptr( const move_ptrs::move_source<static_move_ptr>& src )


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.