### PR TITLE
Fix invalid XHTML markup in docs

### DIFF
--- a/doc/associative_ptr_container.html
+++ b/doc/associative_ptr_container.html
@@ -529,7 +529,7 @@ given <tt class="docutils literal"><span class="pre">ptr_set&lt;T&gt;</span></tt
 - Effects: returns the object with key ``key``
 
 - Throws: ``bad_ptr_container_operation`` if the key does not exist                                  -->
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/associative_ptr_container.rst
+++ b/doc/associative_ptr_container.rst
@@ -216,7 +216,7 @@ Semantics: algorithms
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 	
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/examples.html
+++ b/doc/examples.html
@@ -886,7 +886,7 @@ as view into other containers:
 <li><a class="reference external" href="ptr_container.html">home</a></li>
 <li><a class="reference external" href="reference.html">reference</a></li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -180,7 +180,7 @@ The source code can also be found `here <../test/tut1.cpp>`_.
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 **Navigate:**
 
@@ -189,7 +189,7 @@ The source code can also be found `here <../test/tut1.cpp>`_.
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/faq.html
+++ b/doc/faq.html
@@ -373,7 +373,7 @@ these references: <a class="reference" href="ptr_container.html#references">[11]
 <p>Storing a null-pointer among a list of pointers does not fit well into the Object Oriented paradigm. 
 The most elegant design is to use the Null-Object Pattern where one basically makes a concrete
 class with dummy implementations of the virtual functions. See <a class="reference" href="ptr_container.html#references">[13]</a> for details.</p>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -95,7 +95,7 @@ class with dummy implementations of the virtual functions. See `[13] <ptr_contai
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/guidelines.html
+++ b/doc/guidelines.html
@@ -414,12 +414,12 @@ your OO-code still does not need to worry about null-pointers.</p>
 </ul>
 <p>Finally you might end up in a situation where not even the Null Object can help
 you. That is when you truly need <tt class="docutils literal"><span class="pre">container&lt;</span> <span class="pre">nullable&lt;T&gt;</span> <span class="pre">&gt;</span></tt>.</p>
-<hr><p><strong>Navigate:</strong></p>
+<hr/><p><strong>Navigate:</strong></p>
 <ul class="simple">
 <li><a class="reference" href="ptr_container.html">home</a></li>
 <li><a class="reference" href="reference.html">reference</a></li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/guidelines.rst
+++ b/doc/guidelines.rst
@@ -144,7 +144,7 @@ you. That is when you truly need ``container< nullable<T> >``.
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 **Navigate:**
 
@@ -153,7 +153,7 @@ you. That is when you truly need ``container< nullable<T> >``.
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/headers.html
+++ b/doc/headers.html
@@ -375,7 +375,7 @@ and functions <tt class="docutils literal"><span class="pre">new_clone()</span><
 <li><a class="reference" href="ptr_container.html">home</a></li>
 <li><a class="reference" href="reference.html">reference</a></li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/headers.rst
+++ b/doc/headers.rst
@@ -75,7 +75,7 @@ Library headers
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/indirect_fun.html
+++ b/doc/indirect_fun.html
@@ -401,7 +401,7 @@ namespace boost
          
 } // namespace 'boost'  
 </pre>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/indirect_fun.rst
+++ b/doc/indirect_fun.rst
@@ -127,7 +127,7 @@ first operation is expanded inline.
         
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_array.html
+++ b/doc/ptr_array.html
@@ -660,7 +660,7 @@ explicit ptr_array( const ptr_array&lt;U,N&gt;&amp; r );</tt></p>
 </blockquote>
 </li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_array.rst
+++ b/doc/ptr_array.rst
@@ -281,7 +281,7 @@ Semantics: pointer container requirements
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_container.html
+++ b/doc/ptr_container.html
@@ -735,7 +735,7 @@ Item 226, <a class="reference external" href="http://gcc.gnu.org/onlinedocs/libs
 <tr><td class="label">[13]</td><td>Kevlin Henney, <a class="reference external" href="http://www.two-sdg.demon.co.uk/curbralan/papers/europlop/NullObject.pdf">Null Object</a>, 2002.</td></tr>
 </tbody>
 </table>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_container.rst
+++ b/doc/ptr_container.rst
@@ -384,7 +384,7 @@ __ http://www.two-sdg.demon.co.uk/curbralan/papers/europlop/NullObject.pdf
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright: Thorsten Ottosen 2004-2006. 
 

--- a/doc/ptr_deque.html
+++ b/doc/ptr_deque.html
@@ -526,7 +526,7 @@ namespace boost
 </blockquote>
 </li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_deque.rst
+++ b/doc/ptr_deque.rst
@@ -170,7 +170,7 @@ Semantics: pointer container requirements
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_inserter.html
+++ b/doc/ptr_inserter.html
@@ -348,7 +348,7 @@ namespace boost
     } // namespace 'ptr_container'
 } // namespace 'boost'  
 </pre>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_inserter.rst
+++ b/doc/ptr_inserter.rst
@@ -70,7 +70,7 @@ can be transfered as well.
         
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2008. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_list.html
+++ b/doc/ptr_list.html
@@ -500,7 +500,7 @@ namespace boost
 </blockquote>
 </li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_list.rst
+++ b/doc/ptr_list.rst
@@ -146,7 +146,7 @@ Semantics: list operations
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_map.html
+++ b/doc/ptr_map.html
@@ -342,7 +342,7 @@ namespace boost
 
 } // namespace 'boost'  
 </pre>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_map.rst
+++ b/doc/ptr_map.rst
@@ -63,7 +63,7 @@ to store the pointers.
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_map_adapter.html
+++ b/doc/ptr_map_adapter.html
@@ -556,7 +556,7 @@ An object is only transferred if no equivalent object exists.</li>
 </blockquote>
 </li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_map_adapter.rst
+++ b/doc/ptr_map_adapter.rst
@@ -194,7 +194,7 @@ Semantics: pointer container requirements
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
  
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_multimap_adapter.html
+++ b/doc/ptr_multimap_adapter.html
@@ -540,7 +540,7 @@ is propagated to the pointer (that is, to <tt class="docutils literal">second</t
 </blockquote>
 </li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_multimap_adapter.rst
+++ b/doc/ptr_multimap_adapter.rst
@@ -189,7 +189,7 @@ Semantics: pointer container requirements
  
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_multiset.html
+++ b/doc/ptr_multiset.html
@@ -349,7 +349,7 @@ namespace boost
 <ul class="simple">
 <li>Using <tt class="docutils literal"><span class="pre">nullable&lt;T&gt;</span></tt> as <tt class="docutils literal"><span class="pre">Key</span></tt> is meaningless and is not allowed</li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_multiset.rst
+++ b/doc/ptr_multiset.rst
@@ -70,7 +70,7 @@ to store the pointers.
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_multiset_adapter.html
+++ b/doc/ptr_multiset_adapter.html
@@ -491,7 +491,7 @@ namespace boost
 </blockquote>
 </li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_multiset_adapter.rst
+++ b/doc/ptr_multiset_adapter.rst
@@ -134,7 +134,7 @@ Semantics: pointer container requirements
  
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_sequence_adapter.html
+++ b/doc/ptr_sequence_adapter.html
@@ -827,7 +827,7 @@ ensuring the new sequence is also sorted</li>
 </blockquote>
 </li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_sequence_adapter.rst
+++ b/doc/ptr_sequence_adapter.rst
@@ -443,7 +443,7 @@ contain any nulls*.
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
     
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_set.html
+++ b/doc/ptr_set.html
@@ -350,7 +350,7 @@ namespace boost
 <ul class="simple">
 <li>Using <tt class="docutils literal"><span class="pre">nullable&lt;T&gt;</span></tt> as <tt class="docutils literal"><span class="pre">Key</span></tt> is meaningless and is not allowed</li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_set.rst
+++ b/doc/ptr_set.rst
@@ -72,7 +72,7 @@ to store the pointers.
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_set_adapter.html
+++ b/doc/ptr_set_adapter.html
@@ -491,7 +491,7 @@ An object is only transferred if no equivalent object exists.</li>
 </blockquote>
 </li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_set_adapter.rst
+++ b/doc/ptr_set_adapter.rst
@@ -136,7 +136,7 @@ Semantics: pointer container requirements
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
  
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/ptr_vector.html
+++ b/doc/ptr_vector.html
@@ -550,7 +550,7 @@ and an exception is thrown, the container fails to take ownership.</li>
 </blockquote>
 </li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/ptr_vector.rst
+++ b/doc/ptr_vector.rst
@@ -185,7 +185,7 @@ Semantics: C-array support
     
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2007. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/reference.html
+++ b/doc/reference.html
@@ -797,11 +797,11 @@ you are absolutely certain that all headers are compiled the same way. Otherwise
 you might end up breaking the One Definition Rule.</p>
 <p>If <tt class="docutils literal"><span class="pre">BOOST_NO_EXCEPTIONS</span></tt> is defined, then <tt class="docutils literal"><span class="pre">BOOST_PTR_CONTAINER_NO_EXCEPTIONS</span></tt>
 is also defined.</p>
-<hr><p><strong>Navigate:</strong></p>
+<hr/><p><strong>Navigate:</strong></p>
 <ul class="simple">
 <li><a class="reference" href="ptr_container.html">home</a></li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -486,7 +486,7 @@ is also defined.
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 **Navigate:**
 
@@ -494,7 +494,7 @@ is also defined.
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2007. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/reversible_ptr_container.html
+++ b/doc/reversible_ptr_container.html
@@ -885,7 +885,7 @@ void serialize( Archive&amp; ar, reversible_ptr_container&lt;T,CA,VPC&gt;&amp; c
 Boost.Serialization</li>
 <li>Exception safety: Loading gives the basic guarantee</li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/reversible_ptr_container.rst
+++ b/doc/reversible_ptr_container.rst
@@ -506,7 +506,7 @@ All containers can be serialized by means of
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2007. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/tutorial.html
+++ b/doc/tutorial.html
@@ -773,7 +773,7 @@ zoo.merge( another_zoo );
 BOOST_ASSERT( another_zoo.empty() );
 </pre>
 <p>That is all; now you have learned all the basics!</p>
-<hr><p><strong>See also</strong></p>
+<hr/><p><strong>See also</strong></p>
 <ul class="simple">
 <li><a class="reference external" href="guidelines.html">Usage guidelines</a></li>
 <li><a class="reference external" href="../../conversion/cast.htm#Polymorphic_castl">Cast utilities</a></li>
@@ -783,7 +783,7 @@ BOOST_ASSERT( another_zoo.empty() );
 <li><a class="reference external" href="ptr_container.html">home</a></li>
 <li><a class="reference external" href="examples.html">examples</a></li>
 </ul>
-<hr><table class="docutils field-list" frame="void" rules="none">
+<hr/><table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -440,7 +440,7 @@ That is all; now you have learned all the basics!
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
         
 **See also**
 
@@ -455,7 +455,7 @@ That is all; now you have learned all the basics!
 
 .. raw:: html 
 
-        <hr>
+        <hr/>
 
 :Copyright:     Thorsten Ottosen 2004-2006. Use, modification and distribution is subject to the Boost Software License, Version 1.0 (see LICENSE_1_0.txt__).
 

--- a/doc/tutorial_example.html
+++ b/doc/tutorial_example.html
@@ -1,12 +1,12 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
 <title> </title>
-<link rel="stylesheet" href="default.css" type="text/css">
+<link rel="stylesheet" href="default.css" type="text/css"/>
 </head>
 
 <body>
-    <pre><span class=comment>//
+    <pre><span class="comment">//
 // Boost.Pointer Container
 //
 //  Copyright Thorsten Ottosen 2003-2005. Use, modification and
@@ -30,149 +30,149 @@
 //
 // First we select which container to use.
 //</span>
-<span class=preprocessor>#include</span> <span class=special>&lt;</span><span class=identifier>boost</span><span class=special>/</span><span class=identifier>ptr_container</span><span class=special>/</span><span class=identifier>ptr_deque</span><span class=special>.</span><span class=identifier>hpp</span><span class=special>&gt;</span>
+<span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">ptr_container</span><span class="special">/</span><span class="identifier">ptr_deque</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
 
-<span class=comment>//
+<span class="comment">//
 // we need these later in the example
 //</span>
-<span class=preprocessor>#include</span> <span class=special>&lt;</span><span class=identifier>boost</span><span class=special>/</span><span class=identifier>assert</span><span class=special>.</span><span class=identifier>hpp</span><span class=special>&gt;</span>
-<span class=preprocessor>#include</span> <span class=special>&lt;</span><span class=identifier>string</span><span class=special>&gt;</span>
-<span class=preprocessor>#include</span> <span class=special>&lt;</span><span class=identifier>exception</span><span class=special>&gt;</span>
+<span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">assert</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">string</span><span class="special">&gt;</span>
+<span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">exception</span><span class="special">&gt;</span>
 
 
-<span class=comment>//
+<span class="comment">//
 // Then we define a small polymorphic class
 // hierarchy.
 //</span> 
 
-<span class=keyword>class</span> <span class=identifier>animal</span> <span class=special>:</span> <span class=identifier>boost</span><span class=special>::</span><span class=identifier>noncopyable</span>
-<span class=special>{</span>
-    <span class=keyword>virtual</span> <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span> <span class=identifier>do_speak</span><span class=special>()</span> <span class=keyword>const</span> <span class=special>=</span> <span class=number>0</span><span class=special>;</span>
-    <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span> <span class=identifier>name_</span><span class=special>;</span>
+<span class="keyword">class</span> <span class="identifier">animal</span> <span class="special">:</span> <span class="identifier">boost</span><span class="special">::</span><span class="identifier">noncopyable</span>
+<span class="special">{</span>
+    <span class="keyword">virtual</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span> <span class="identifier">do_speak</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">=</span> <span class="number">0</span><span class="special">;</span>
+    <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span> <span class="identifier">name_</span><span class="special">;</span>
 
-<span class=keyword>protected</span><span class=special>:</span>
-    <span class=comment>//
+<span class="keyword">protected</span><span class="special">:</span>
+    <span class="comment">//
     // Animals cannot be copied...
     //</span>
-    <span class=identifier>animal</span><span class=special>(</span> <span class=keyword>const</span> <span class=identifier>animal</span><span class=special>&amp;</span> <span class=identifier>r</span> <span class=special>)</span> <span class=special>:</span> <span class=identifier>name_</span><span class=special>(</span> <span class=identifier>r</span><span class=special>.</span><span class=identifier>name_</span> <span class=special>)</span>           <span class=special>{</span> <span class=special>}</span>
-    <span class=keyword>void</span> <span class=keyword>operator</span><span class=special>=(</span> <span class=keyword>const</span> <span class=identifier>animal</span><span class=special>&amp;</span> <span class=special>);</span>
+    <span class="identifier">animal</span><span class="special">(</span> <span class="keyword">const</span> <span class="identifier">animal</span><span class="special">&amp;</span> <span class="identifier">r</span> <span class="special">)</span> <span class="special">:</span> <span class="identifier">name_</span><span class="special">(</span> <span class="identifier">r</span><span class="special">.</span><span class="identifier">name_</span> <span class="special">)</span>           <span class="special">{</span> <span class="special">}</span>
+    <span class="keyword">void</span> <span class="keyword">operator</span><span class="special">=(</span> <span class="keyword">const</span> <span class="identifier">animal</span><span class="special">&amp;</span> <span class="special">);</span>
 
-<span class=keyword>private</span><span class=special>:</span>
-    <span class=comment>//
+<span class="keyword">private</span><span class="special">:</span>
+    <span class="comment">//
     // ...but due to advances in genetics, we can clone them!
     //</span>
 
-    <span class=keyword>virtual</span> <span class=identifier>animal</span><span class=special>*</span> <span class=identifier>do_clone</span><span class=special>()</span> <span class=keyword>const</span> <span class=special>=</span> <span class=number>0</span><span class=special>;</span>
+    <span class="keyword">virtual</span> <span class="identifier">animal</span><span class="special">*</span> <span class="identifier">do_clone</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">=</span> <span class="number">0</span><span class="special">;</span>
         
-<span class=keyword>public</span><span class=special>:</span>
-    <span class=identifier>animal</span><span class=special>(</span> <span class=keyword>const</span> <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span><span class=special>&amp;</span> <span class=identifier>name</span> <span class=special>)</span> <span class=special>:</span> <span class=identifier>name_</span><span class=special>(</span><span class=identifier>name</span><span class=special>)</span>        <span class=special>{</span> <span class=special>}</span>
-    <span class=keyword>virtual</span> <span class=special>~</span><span class=identifier>animal</span><span class=special>()</span> <span class=keyword>throw</span><span class=special>()</span>                              <span class=special>{</span> <span class=special>}</span>
+<span class="keyword">public</span><span class="special">:</span>
+    <span class="identifier">animal</span><span class="special">(</span> <span class="keyword">const</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span><span class="special">&amp;</span> <span class="identifier">name</span> <span class="special">)</span> <span class="special">:</span> <span class="identifier">name_</span><span class="special">(</span><span class="identifier">name</span><span class="special">)</span>        <span class="special">{</span> <span class="special">}</span>
+    <span class="keyword">virtual</span> <span class="special">~</span><span class="identifier">animal</span><span class="special">()</span> <span class="keyword">throw</span><span class="special">()</span>                              <span class="special">{</span> <span class="special">}</span>
     
-    <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span> <span class=identifier>speak</span><span class=special>()</span> <span class=keyword>const</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=identifier>do_speak</span><span class=special>();</span>
-    <span class=special>}</span>
+    <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span> <span class="identifier">speak</span><span class="special">()</span> <span class="keyword">const</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="identifier">do_speak</span><span class="special">();</span>
+    <span class="special">}</span>
 
-    <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span> <span class=identifier>name</span><span class=special>()</span> <span class=keyword>const</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=identifier>name_</span><span class=special>;</span>
-    <span class=special>}</span>
+    <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span> <span class="identifier">name</span><span class="special">()</span> <span class="keyword">const</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="identifier">name_</span><span class="special">;</span>
+    <span class="special">}</span>
 
-    <span class=identifier>animal</span><span class=special>*</span> <span class=identifier>clone</span><span class=special>()</span> <span class=keyword>const</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=identifier>do_clone</span><span class=special>();</span>
-    <span class=special>}</span>
-<span class=special>};</span>
+    <span class="identifier">animal</span><span class="special">*</span> <span class="identifier">clone</span><span class="special">()</span> <span class="keyword">const</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="identifier">do_clone</span><span class="special">();</span>
+    <span class="special">}</span>
+<span class="special">};</span>
 
-<span class=comment>//
+<span class="comment">//
 // An animal is still not Clonable. We need this last hook.
 //
 // Notice that we pass the animal by const reference
 // and return by pointer.
 //</span>
 
-<span class=identifier>animal</span><span class=special>*</span> <span class=identifier>new_clone</span><span class=special>(</span> <span class=keyword>const</span> <span class=identifier>animal</span><span class=special>&amp;</span> <span class=identifier>a</span> <span class=special>)</span>
-<span class=special>{</span>
-    <span class=keyword>return</span> <span class=identifier>a</span><span class=special>.</span><span class=identifier>clone</span><span class=special>();</span>
-<span class=special>}</span>
+<span class="identifier">animal</span><span class="special">*</span> <span class="identifier">new_clone</span><span class="special">(</span> <span class="keyword">const</span> <span class="identifier">animal</span><span class="special">&amp;</span> <span class="identifier">a</span> <span class="special">)</span>
+<span class="special">{</span>
+    <span class="keyword">return</span> <span class="identifier">a</span><span class="special">.</span><span class="identifier">clone</span><span class="special">();</span>
+<span class="special">}</span>
 
-<span class=comment>//
+<span class="comment">//
 // We do not need to define 'delete_clone()' since
 // since the default is to call the default 'operator delete()'.
 //</span>
 
-<span class=keyword>const</span> <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span> <span class=identifier>muuuh</span> <span class=special>=</span> <span class=string>&quot;Muuuh!&quot;</span><span class=special>;</span>
-<span class=keyword>const</span> <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span> <span class=identifier>oiink</span> <span class=special>=</span> <span class=string>&quot;Oiiink&quot;</span><span class=special>;</span>
+<span class="keyword">const</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span> <span class="identifier">muuuh</span> <span class="special">=</span> <span class="string">&quot;Muuuh!&quot;</span><span class="special">;</span>
+<span class="keyword">const</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span> <span class="identifier">oiink</span> <span class="special">=</span> <span class="string">&quot;Oiiink&quot;</span><span class="special">;</span>
 
-<span class=keyword>class</span> <span class=identifier>cow</span> <span class=special>:</span> <span class=keyword>public</span> <span class=identifier>animal</span>
-<span class=special>{</span>
-    <span class=keyword>virtual</span> <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span> <span class=identifier>do_speak</span><span class=special>()</span> <span class=keyword>const</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=identifier>muuuh</span><span class=special>;</span>
-    <span class=special>}</span>
+<span class="keyword">class</span> <span class="identifier">cow</span> <span class="special">:</span> <span class="keyword">public</span> <span class="identifier">animal</span>
+<span class="special">{</span>
+    <span class="keyword">virtual</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span> <span class="identifier">do_speak</span><span class="special">()</span> <span class="keyword">const</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="identifier">muuuh</span><span class="special">;</span>
+    <span class="special">}</span>
 
-    <span class=keyword>virtual</span> <span class=identifier>animal</span><span class=special>*</span> <span class=identifier>do_clone</span><span class=special>()</span> <span class=keyword>const</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=keyword>new</span> <span class=identifier>cow</span><span class=special>(</span> <span class=special>*</span><span class=keyword>this</span> <span class=special>);</span>
-    <span class=special>}</span>
+    <span class="keyword">virtual</span> <span class="identifier">animal</span><span class="special">*</span> <span class="identifier">do_clone</span><span class="special">()</span> <span class="keyword">const</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="keyword">new</span> <span class="identifier">cow</span><span class="special">(</span> <span class="special">*</span><span class="keyword">this</span> <span class="special">);</span>
+    <span class="special">}</span>
 
-<span class=keyword>public</span><span class=special>:</span>
-    <span class=identifier>cow</span><span class=special>(</span> <span class=keyword>const</span> <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span><span class=special>&amp;</span> <span class=identifier>name</span> <span class=special>)</span> <span class=special>:</span> <span class=identifier>animal</span><span class=special>(</span><span class=identifier>name</span><span class=special>)</span>          <span class=special>{</span> <span class=special>}</span>
-<span class=special>};</span>
+<span class="keyword">public</span><span class="special">:</span>
+    <span class="identifier">cow</span><span class="special">(</span> <span class="keyword">const</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span><span class="special">&amp;</span> <span class="identifier">name</span> <span class="special">)</span> <span class="special">:</span> <span class="identifier">animal</span><span class="special">(</span><span class="identifier">name</span><span class="special">)</span>          <span class="special">{</span> <span class="special">}</span>
+<span class="special">};</span>
 
-<span class=keyword>class</span> <span class=identifier>pig</span> <span class=special>:</span> <span class=keyword>public</span> <span class=identifier>animal</span>
-<span class=special>{</span>
-    <span class=keyword>virtual</span> <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span> <span class=identifier>do_speak</span><span class=special>()</span> <span class=keyword>const</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=identifier>oiink</span><span class=special>;</span>
-    <span class=special>}</span>
+<span class="keyword">class</span> <span class="identifier">pig</span> <span class="special">:</span> <span class="keyword">public</span> <span class="identifier">animal</span>
+<span class="special">{</span>
+    <span class="keyword">virtual</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span> <span class="identifier">do_speak</span><span class="special">()</span> <span class="keyword">const</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="identifier">oiink</span><span class="special">;</span>
+    <span class="special">}</span>
 
-    <span class=keyword>virtual</span> <span class=identifier>animal</span><span class=special>*</span> <span class=identifier>do_clone</span><span class=special>()</span> <span class=keyword>const</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=keyword>new</span> <span class=identifier>pig</span><span class=special>(</span> <span class=special>*</span><span class=keyword>this</span> <span class=special>);</span>
-    <span class=special>}</span>
+    <span class="keyword">virtual</span> <span class="identifier">animal</span><span class="special">*</span> <span class="identifier">do_clone</span><span class="special">()</span> <span class="keyword">const</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="keyword">new</span> <span class="identifier">pig</span><span class="special">(</span> <span class="special">*</span><span class="keyword">this</span> <span class="special">);</span>
+    <span class="special">}</span>
     
-<span class=keyword>public</span><span class=special>:</span>
-    <span class=identifier>pig</span><span class=special>(</span> <span class=keyword>const</span> <span class=identifier>std</span><span class=special>::</span><span class=identifier>string</span><span class=special>&amp;</span> <span class=identifier>name</span> <span class=special>)</span> <span class=special>:</span> <span class=identifier>animal</span><span class=special>(</span><span class=identifier>name</span><span class=special>)</span>          <span class=special>{</span> <span class=special>}</span>
-<span class=special>};</span>
+<span class="keyword">public</span><span class="special">:</span>
+    <span class="identifier">pig</span><span class="special">(</span> <span class="keyword">const</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">string</span><span class="special">&amp;</span> <span class="identifier">name</span> <span class="special">)</span> <span class="special">:</span> <span class="identifier">animal</span><span class="special">(</span><span class="identifier">name</span><span class="special">)</span>          <span class="special">{</span> <span class="special">}</span>
+<span class="special">};</span>
 
-<span class=comment>//
+<span class="comment">//
 // Then we, of course, need a place to put all
 // those animals.
 //</span>
 
-<span class=keyword>class</span> <span class=identifier>farm</span>
-<span class=special>{</span>
-    <span class=comment>//
+<span class="keyword">class</span> <span class="identifier">farm</span>
+<span class="special">{</span>
+    <span class="comment">//
     // This is where the smart containers are handy
     //</span>
-    <span class=keyword>typedef</span> <span class=identifier>boost</span><span class=special>::</span><span class=identifier>ptr_deque</span><span class=special>&lt;</span><span class=identifier>animal</span><span class=special>&gt;</span> <span class=identifier>barn_type</span><span class=special>;</span>
-    <span class=identifier>barn_type</span>                        <span class=identifier>barn</span><span class=special>;</span>
+    <span class="keyword">typedef</span> <span class="identifier">boost</span><span class="special">::</span><span class="identifier">ptr_deque</span><span class="special">&lt;</span><span class="identifier">animal</span><span class="special">&gt;</span> <span class="identifier">barn_type</span><span class="special">;</span>
+    <span class="identifier">barn_type</span>                        <span class="identifier">barn</span><span class="special">;</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // A convenience typedef for the compiler-appropriate
     // smart pointer used to manage barns
     //</span>    
-    <span class=keyword>typedef</span> <span class=identifier><a href="compatible_smart_ptr.html"><em>compatible-smart-ptr</em></a></span><span class=special>&lt;</span><span class=identifier>barn_type</span><span class=special>&gt;</span> <span class=identifier>raii_ptr</span><span class=special>;</span>
+    <span class="keyword">typedef</span> <span class="identifier"><a href="compatible_smart_ptr.html"><em>compatible-smart-ptr</em></a></span><span class="special">&lt;</span><span class="identifier">barn_type</span><span class="special">&gt;</span> <span class="identifier">raii_ptr</span><span class="special">;</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // An error type
     //</span>
-    <span class=keyword>struct</span> <span class=identifier>farm_trouble</span> <span class=special>:</span> <span class=keyword>public</span> <span class=identifier>std</span><span class=special>::</span><span class=identifier>exception</span>           <span class=special>{</span> <span class=special>};</span>
+    <span class="keyword">struct</span> <span class="identifier">farm_trouble</span> <span class="special">:</span> <span class="keyword">public</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">exception</span>           <span class="special">{</span> <span class="special">};</span>
 
-<span class=keyword>public</span><span class=special>:</span>
-    <span class=comment>// 
+<span class="keyword">public</span><span class="special">:</span>
+    <span class="comment">// 
     // We would like to make it possible to
     // iterate over the animals in the farm
     //</span>
-    <span class=keyword>typedef</span> <span class=identifier>barn_type</span><span class=special>::</span><span class=identifier>iterator</span>  <span class=identifier>animal_iterator</span><span class=special>;</span>
+    <span class="keyword">typedef</span> <span class="identifier">barn_type</span><span class="special">::</span><span class="identifier">iterator</span>  <span class="identifier">animal_iterator</span><span class="special">;</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // We also need to count the farm's size...
     //</span>
-    <span class=keyword>typedef</span> <span class=identifier>barn_type</span><span class=special>::</span><span class=identifier>size_type</span> <span class=identifier>size_type</span><span class=special>;</span>
+    <span class="keyword">typedef</span> <span class="identifier">barn_type</span><span class="special">::</span><span class="identifier">size_type</span> <span class="identifier">size_type</span><span class="special">;</span>
     
-    <span class=comment>//
+    <span class="comment">//
     // And we also want to transfer an animal
     // safely around. The easiest way to think
     // about '::auto_type' is to imagine a simplified
@@ -184,100 +184,100 @@
     //
     // but not more.
     //</span>
-    <span class=keyword>typedef</span> <span class=identifier>barn_type</span><span class=special>::</span><span class=identifier>auto_type</span>  <span class=identifier>animal_transport</span><span class=special>;</span>
+    <span class="keyword">typedef</span> <span class="identifier">barn_type</span><span class="special">::</span><span class="identifier">auto_type</span>  <span class="identifier">animal_transport</span><span class="special">;</span>
 
-    <span class=comment>// 
+    <span class="comment">// 
     // Create an empty farm.
     //</span>
-    <span class=identifier>farm</span><span class=special>()</span>                                                 <span class=special>{</span> <span class=special>}</span>
+    <span class="identifier">farm</span><span class="special">()</span>                                                 <span class="special">{</span> <span class="special">}</span>
     
-    <span class=comment>//
+    <span class="comment">//
     // We need a constructor that can make a new
     // farm by cloning a range of animals.
     //</span>
-    <span class=identifier>farm</span><span class=special>(</span> <span class=identifier>animal_iterator</span> <span class=identifier>begin</span><span class=special>,</span> <span class=identifier>animal_iterator</span> <span class=identifier>end</span> <span class=special>)</span>
-     <span class=special>:</span> 
-        <span class=comment>//
+    <span class="identifier">farm</span><span class="special">(</span> <span class="identifier">animal_iterator</span> <span class="identifier">begin</span><span class="special">,</span> <span class="identifier">animal_iterator</span> <span class="identifier">end</span> <span class="special">)</span>
+     <span class="special">:</span> 
+        <span class="comment">//
         // Objects are always cloned before insertion
         // unless we explicitly add a pointer or 
         // use 'release()'. Therefore we actually
         // clone all animals in the range
         //</span>
-        <span class=identifier>barn</span><span class=special>(</span> <span class=identifier>begin</span><span class=special>,</span> <span class=identifier>end</span> <span class=special>)</span>                               <span class=special>{</span> <span class=special>}</span>
+        <span class="identifier">barn</span><span class="special">(</span> <span class="identifier">begin</span><span class="special">,</span> <span class="identifier">end</span> <span class="special">)</span>                               <span class="special">{</span> <span class="special">}</span>
     
-    <span class=comment>//
+    <span class="comment">//
     // ... so we need some other function too
     //</span>
 
-    <span class=identifier>animal_iterator</span> <span class=identifier>begin</span><span class=special>()</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=identifier>barn</span><span class=special>.</span><span class=identifier>begin</span><span class=special>();</span>
-    <span class=special>}</span>
+    <span class="identifier">animal_iterator</span> <span class="identifier">begin</span><span class="special">()</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="identifier">barn</span><span class="special">.</span><span class="identifier">begin</span><span class="special">();</span>
+    <span class="special">}</span>
 
-    <span class=identifier>animal_iterator</span> <span class=identifier>end</span><span class=special>()</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=identifier>barn</span><span class=special>.</span><span class=identifier>end</span><span class=special>();</span>
-    <span class=special>}</span>
+    <span class="identifier">animal_iterator</span> <span class="identifier">end</span><span class="special">()</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="identifier">barn</span><span class="special">.</span><span class="identifier">end</span><span class="special">();</span>
+    <span class="special">}</span>
     
-    <span class=comment>//
+    <span class="comment">//
     // Here it is quite ok to have an 'animal*' argument.
     // The smart container will handle all ownership
     // issues.
     //</span>
-    <span class=keyword>void</span> <span class=identifier>buy_animal</span><span class=special>(</span> <span class=identifier>animal</span><span class=special>*</span> <span class=identifier>a</span> <span class=special>)</span>
-    <span class=special>{</span>
-        <span class=identifier>barn</span><span class=special>.</span><span class=identifier>push_back</span><span class=special>(</span> <span class=identifier>a</span> <span class=special>);</span>
-    <span class=special>}</span>
+    <span class="keyword">void</span> <span class="identifier">buy_animal</span><span class="special">(</span> <span class="identifier">animal</span><span class="special">*</span> <span class="identifier">a</span> <span class="special">)</span>
+    <span class="special">{</span>
+        <span class="identifier">barn</span><span class="special">.</span><span class="identifier">push_back</span><span class="special">(</span> <span class="identifier">a</span> <span class="special">);</span>
+    <span class="special">}</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // The farm can also be in economical trouble and
     // therefore be in the need to sell animals.
     //</span>
-    <span class=identifier>animal_transport</span> <span class=identifier>sell_animal</span><span class=special>(</span> <span class=identifier>animal_iterator</span> <span class=identifier>to_sell</span> <span class=special>)</span>
-    <span class=special>{</span>
-        <span class=keyword>if</span><span class=special>(</span> <span class=identifier>to_sell</span> <span class=special>==</span> <span class=identifier>end</span><span class=special>()</span> <span class=special>)</span>
-            <span class=keyword>throw</span> <span class=identifier>farm_trouble</span><span class=special>();</span>
+    <span class="identifier">animal_transport</span> <span class="identifier">sell_animal</span><span class="special">(</span> <span class="identifier">animal_iterator</span> <span class="identifier">to_sell</span> <span class="special">)</span>
+    <span class="special">{</span>
+        <span class="keyword">if</span><span class="special">(</span> <span class="identifier">to_sell</span> <span class="special">==</span> <span class="identifier">end</span><span class="special">()</span> <span class="special">)</span>
+            <span class="keyword">throw</span> <span class="identifier">farm_trouble</span><span class="special">();</span>
 
-        <span class=comment>//
+        <span class="comment">//
         // Here we remove the animal from the barn,
         // but the animal is not deleted yet...it's
         // up to the buyer to decide what
         // to do with it.
         //</span>
-        <span class=keyword>return</span> <span class=identifier>barn</span><span class=special>.</span><span class=identifier>release</span><span class=special>(</span> <span class=identifier>to_sell</span> <span class=special>);</span>
-    <span class=special>}</span>
+        <span class="keyword">return</span> <span class="identifier">barn</span><span class="special">.</span><span class="identifier">release</span><span class="special">(</span> <span class="identifier">to_sell</span> <span class="special">);</span>
+    <span class="special">}</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // How big a farm do we have?
     //</span>
-    <span class=identifier>size_type</span> <span class=identifier>size</span><span class=special>()</span> <span class=keyword>const</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=identifier>barn</span><span class=special>.</span><span class=identifier>size</span><span class=special>();</span>
-    <span class=special>}</span>
+    <span class="identifier">size_type</span> <span class="identifier">size</span><span class="special">()</span> <span class="keyword">const</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="identifier">barn</span><span class="special">.</span><span class="identifier">size</span><span class="special">();</span>
+    <span class="special">}</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // If things are bad, we might choose to sell all animals :-(
       //</span>
 
-    <span class=identifier>raii_ptr</span> <span class=identifier>sell_farm</span><span class=special>()</span>
-    <span class=special>{</span>
-        <span class=keyword>return</span> <span class=identifier>barn</span><span class=special>.</span><span class=identifier>release</span><span class=special>();</span>
-    <span class=special>}</span>
+    <span class="identifier">raii_ptr</span> <span class="identifier">sell_farm</span><span class="special">()</span>
+    <span class="special">{</span>
+        <span class="keyword">return</span> <span class="identifier">barn</span><span class="special">.</span><span class="identifier">release</span><span class="special">();</span>
+    <span class="special">}</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // However, if things are good, we might buy somebody
     // else's farm :-)
     //</span>
 
-    <span class=keyword>void</span> <span class=identifier>buy_farm</span><span class=special>(</span> <span class=identifier>raii_ptr</span> <span class=identifier>other</span> <span class=special>)</span>
-    <span class=special>{</span>
-        <span class=comment>//
+    <span class="keyword">void</span> <span class="identifier">buy_farm</span><span class="special">(</span> <span class="identifier">raii_ptr</span> <span class="identifier">other</span> <span class="special">)</span>
+    <span class="special">{</span>
+        <span class="comment">//
         // This line inserts all the animals from 'other'
         // and is guaranteed either to succeed or to have no
         // effect
         //</span>
-        <span class=identifier>barn</span><span class=special>.</span><span class=identifier>transfer</span><span class=special>(</span> <span class=identifier>barn</span><span class=special>.</span><span class=identifier>end</span><span class=special>(),</span> <span class=comment>// insert new animals at the end</span>
-                         <span class=special>*</span><span class=identifier>other</span> <span class=special>);</span>     <span class=comment>// we want to transfer all animals,
+        <span class="identifier">barn</span><span class="special">.</span><span class="identifier">transfer</span><span class="special">(</span> <span class="identifier">barn</span><span class="special">.</span><span class="identifier">end</span><span class="special">(),</span> <span class="comment">// insert new animals at the end</span>
+                         <span class="special">*</span><span class="identifier">other</span> <span class="special">);</span>     <span class="comment">// we want to transfer all animals,
                                        // so we use the whole container as argument
         //
         // You might think you would have to do
@@ -286,86 +286,86 @@
         //
         // but '*other' is empty and can go out of scope as it wants
         //</span>
-        <span class=identifier>BOOST_ASSERT</span><span class=special>(</span> <span class=identifier>other</span><span class=special>-&gt;</span><span class=identifier>empty</span><span class=special>()</span> <span class=special>);</span>
-    <span class=special>}</span>
+        <span class="identifier">BOOST_ASSERT</span><span class="special">(</span> <span class="identifier">other</span><span class="special">-&gt;</span><span class="identifier">empty</span><span class="special">()</span> <span class="special">);</span>
+    <span class="special">}</span>
     
-<span class=special>};</span> <span class=comment>// class 'farm'.</span>
+<span class="special">};</span> <span class="comment">// class 'farm'.</span>
 
-<span class=keyword>int</span> <span class=identifier>main</span><span class=special>()</span>
-<span class=special>{</span>
-    <span class=comment>//
+<span class="keyword">int</span> <span class="identifier">main</span><span class="special">()</span>
+<span class="special">{</span>
+    <span class="comment">//
     // First we make a farm
     //</span>
-    <span class=identifier>farm</span> <span class=identifier>animal_farm</span><span class=special>;</span>
-    <span class=identifier>BOOST_ASSERT</span><span class=special>(</span> <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>size</span><span class=special>()</span> <span class=special>==</span> <span class=number>0u</span> <span class=special>);</span>
+    <span class="identifier">farm</span> <span class="identifier">animal_farm</span><span class="special">;</span>
+    <span class="identifier">BOOST_ASSERT</span><span class="special">(</span> <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">size</span><span class="special">()</span> <span class="special">==</span> <span class="number">0u</span> <span class="special">);</span>
     
-    <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>buy_animal</span><span class=special>(</span> <span class=keyword>new</span> <span class=identifier>pig</span><span class=special>(</span><span class=string>&quot;Betty&quot;</span><span class=special>)</span> <span class=special>);</span>
-    <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>buy_animal</span><span class=special>(</span> <span class=keyword>new</span> <span class=identifier>pig</span><span class=special>(</span><span class=string>&quot;Benny&quot;</span><span class=special>)</span> <span class=special>);</span>
-    <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>buy_animal</span><span class=special>(</span> <span class=keyword>new</span> <span class=identifier>pig</span><span class=special>(</span><span class=string>&quot;Jeltzin&quot;</span><span class=special>)</span> <span class=special>);</span>
-    <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>buy_animal</span><span class=special>(</span> <span class=keyword>new</span> <span class=identifier>cow</span><span class=special>(</span><span class=string>&quot;Hanz&quot;</span><span class=special>)</span> <span class=special>);</span>
-    <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>buy_animal</span><span class=special>(</span> <span class=keyword>new</span> <span class=identifier>cow</span><span class=special>(</span><span class=string>&quot;Mary&quot;</span><span class=special>)</span> <span class=special>);</span>
-    <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>buy_animal</span><span class=special>(</span> <span class=keyword>new</span> <span class=identifier>cow</span><span class=special>(</span><span class=string>&quot;Frederik&quot;</span><span class=special>)</span> <span class=special>);</span>
-    <span class=identifier>BOOST_ASSERT</span><span class=special>(</span> <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>size</span><span class=special>()</span> <span class=special>==</span> <span class=number>6u</span> <span class=special>);</span>
+    <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">buy_animal</span><span class="special">(</span> <span class="keyword">new</span> <span class="identifier">pig</span><span class="special">(</span><span class="string">&quot;Betty&quot;</span><span class="special">)</span> <span class="special">);</span>
+    <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">buy_animal</span><span class="special">(</span> <span class="keyword">new</span> <span class="identifier">pig</span><span class="special">(</span><span class="string">&quot;Benny&quot;</span><span class="special">)</span> <span class="special">);</span>
+    <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">buy_animal</span><span class="special">(</span> <span class="keyword">new</span> <span class="identifier">pig</span><span class="special">(</span><span class="string">&quot;Jeltzin&quot;</span><span class="special">)</span> <span class="special">);</span>
+    <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">buy_animal</span><span class="special">(</span> <span class="keyword">new</span> <span class="identifier">cow</span><span class="special">(</span><span class="string">&quot;Hanz&quot;</span><span class="special">)</span> <span class="special">);</span>
+    <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">buy_animal</span><span class="special">(</span> <span class="keyword">new</span> <span class="identifier">cow</span><span class="special">(</span><span class="string">&quot;Mary&quot;</span><span class="special">)</span> <span class="special">);</span>
+    <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">buy_animal</span><span class="special">(</span> <span class="keyword">new</span> <span class="identifier">cow</span><span class="special">(</span><span class="string">&quot;Frederik&quot;</span><span class="special">)</span> <span class="special">);</span>
+    <span class="identifier">BOOST_ASSERT</span><span class="special">(</span> <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">size</span><span class="special">()</span> <span class="special">==</span> <span class="number">6u</span> <span class="special">);</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // Then we make another farm...it will actually contain
     // a clone of the other farm.
     //</span>
-    <span class=identifier>farm</span> <span class=identifier>new_farm</span><span class=special>(</span> <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>begin</span><span class=special>(),</span> <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>end</span><span class=special>()</span> <span class=special>);</span>
-    <span class=identifier>BOOST_ASSERT</span><span class=special>(</span> <span class=identifier>new_farm</span><span class=special>.</span><span class=identifier>size</span><span class=special>()</span> <span class=special>==</span> <span class=number>6u</span> <span class=special>);</span>
+    <span class="identifier">farm</span> <span class="identifier">new_farm</span><span class="special">(</span> <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">begin</span><span class="special">(),</span> <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">end</span><span class="special">()</span> <span class="special">);</span>
+    <span class="identifier">BOOST_ASSERT</span><span class="special">(</span> <span class="identifier">new_farm</span><span class="special">.</span><span class="identifier">size</span><span class="special">()</span> <span class="special">==</span> <span class="number">6u</span> <span class="special">);</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // Is it really clones in the new farm?
     //</span>
-    <span class=identifier>BOOST_ASSERT</span><span class=special>(</span> <span class=identifier>new_farm</span><span class=special>.</span><span class=identifier>begin</span><span class=special>()-&gt;</span><span class=identifier>name</span><span class=special>()</span> <span class=special>==</span> <span class=string>&quot;Betty&quot;</span> <span class=special>);</span>
+    <span class="identifier">BOOST_ASSERT</span><span class="special">(</span> <span class="identifier">new_farm</span><span class="special">.</span><span class="identifier">begin</span><span class="special">()-&gt;</span><span class="identifier">name</span><span class="special">()</span> <span class="special">==</span> <span class="string">&quot;Betty&quot;</span> <span class="special">);</span>
     
-    <span class=comment>//
+    <span class="comment">//
     // Then we search for an animal, Mary (the Crown Princess of Denmark),
     // because we would like to buy her ...
     //</span>
-    <span class=keyword>typedef</span> <span class=identifier>farm</span><span class=special>::</span><span class=identifier>animal_iterator</span> <span class=identifier>iterator</span><span class=special>;</span>
-    <span class=identifier>iterator</span> <span class=identifier>to_sell</span><span class=special>;</span>
-    <span class=keyword>for</span><span class=special>(</span> <span class=identifier>iterator</span> <span class=identifier>i</span>   <span class=special>=</span> <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>begin</span><span class=special>(),</span>
-                  <span class=identifier>end</span> <span class=special>=</span> <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>end</span><span class=special>();</span>
-         <span class=identifier>i</span> <span class=special>!=</span> <span class=identifier>end</span><span class=special>;</span> <span class=special>++</span><span class=identifier>i</span> <span class=special>)</span>
-    <span class=special>{</span>
-        <span class=keyword>if</span><span class=special>(</span> <span class=identifier>i</span><span class=special>-&gt;</span><span class=identifier>name</span><span class=special>()</span> <span class=special>==</span> <span class=string>&quot;Mary&quot;</span> <span class=special>)</span>
-        <span class=special>{</span>
-            <span class=identifier>to_sell</span> <span class=special>=</span> <span class=identifier>i</span><span class=special>;</span>
-            <span class=keyword>break</span><span class=special>;</span>
-        <span class=special>}</span>
-    <span class=special>}</span>
+    <span class="keyword">typedef</span> <span class="identifier">farm</span><span class="special">::</span><span class="identifier">animal_iterator</span> <span class="identifier">iterator</span><span class="special">;</span>
+    <span class="identifier">iterator</span> <span class="identifier">to_sell</span><span class="special">;</span>
+    <span class="keyword">for</span><span class="special">(</span> <span class="identifier">iterator</span> <span class="identifier">i</span>   <span class="special">=</span> <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">begin</span><span class="special">(),</span>
+                  <span class="identifier">end</span> <span class="special">=</span> <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">end</span><span class="special">();</span>
+         <span class="identifier">i</span> <span class="special">!=</span> <span class="identifier">end</span><span class="special">;</span> <span class="special">++</span><span class="identifier">i</span> <span class="special">)</span>
+    <span class="special">{</span>
+        <span class="keyword">if</span><span class="special">(</span> <span class="identifier">i</span><span class="special">-&gt;</span><span class="identifier">name</span><span class="special">()</span> <span class="special">==</span> <span class="string">&quot;Mary&quot;</span> <span class="special">)</span>
+        <span class="special">{</span>
+            <span class="identifier">to_sell</span> <span class="special">=</span> <span class="identifier">i</span><span class="special">;</span>
+            <span class="keyword">break</span><span class="special">;</span>
+        <span class="special">}</span>
+    <span class="special">}</span>
 
-    <span class=identifier>farm</span><span class=special>::</span><span class=identifier>animal_transport</span> <span class=identifier>mary</span> <span class=special>=</span> <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>sell_animal</span><span class=special>(</span> <span class=identifier>to_sell</span> <span class=special>);</span>
+    <span class="identifier">farm</span><span class="special">::</span><span class="identifier">animal_transport</span> <span class="identifier">mary</span> <span class="special">=</span> <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">sell_animal</span><span class="special">(</span> <span class="identifier">to_sell</span> <span class="special">);</span>
 
 
-    <span class=keyword>if</span><span class=special>(</span> <span class=identifier>mary</span><span class=special>-&gt;</span><span class=identifier>speak</span><span class=special>()</span> <span class=special>==</span> <span class=identifier>muuuh</span> <span class=special>)</span>
-        <span class=comment>//
+    <span class="keyword">if</span><span class="special">(</span> <span class="identifier">mary</span><span class="special">-&gt;</span><span class="identifier">speak</span><span class="special">()</span> <span class="special">==</span> <span class="identifier">muuuh</span> <span class="special">)</span>
+        <span class="comment">//
         // Great, Mary is a cow, and she may live longer
         //</span>
-        <span class=identifier>new_farm</span><span class=special>.</span><span class=identifier>buy_animal</span><span class=special>(</span> <span class=identifier>mary</span><span class=special>.</span><span class=identifier>release</span><span class=special>()</span> <span class=special>);</span>
-    <span class=keyword>else</span>
-        <span class=comment>//
+        <span class="identifier">new_farm</span><span class="special">.</span><span class="identifier">buy_animal</span><span class="special">(</span> <span class="identifier">mary</span><span class="special">.</span><span class="identifier">release</span><span class="special">()</span> <span class="special">);</span>
+    <span class="keyword">else</span>
+        <span class="comment">//
         // Then the animal would be destroyed (!)
         // when we go out of scope.
         //</span>
-        <span class=special>;</span>
+        <span class="special">;</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // Now we can observe some changes to the two farms...
     //</span>
-    <span class=identifier>BOOST_ASSERT</span><span class=special>(</span> <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>size</span><span class=special>()</span> <span class=special>==</span> <span class=number>5u</span> <span class=special>);</span>
-    <span class=identifier>BOOST_ASSERT</span><span class=special>(</span> <span class=identifier>new_farm</span><span class=special>.</span><span class=identifier>size</span><span class=special>()</span>    <span class=special>==</span> <span class=number>7u</span> <span class=special>);</span>
+    <span class="identifier">BOOST_ASSERT</span><span class="special">(</span> <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">size</span><span class="special">()</span> <span class="special">==</span> <span class="number">5u</span> <span class="special">);</span>
+    <span class="identifier">BOOST_ASSERT</span><span class="special">(</span> <span class="identifier">new_farm</span><span class="special">.</span><span class="identifier">size</span><span class="special">()</span>    <span class="special">==</span> <span class="number">7u</span> <span class="special">);</span>
 
-    <span class=comment>//
+    <span class="comment">//
     // The new farm has however underestimated how much
     // it cost to feed Mary and its owner is forced to sell the farm...
     //</span>
-    <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>buy_farm</span><span class=special>(</span> <span class=identifier>new_farm</span><span class=special>.</span><span class=identifier>sell_farm</span><span class=special>()</span> <span class=special>);</span>
+    <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">buy_farm</span><span class="special">(</span> <span class="identifier">new_farm</span><span class="special">.</span><span class="identifier">sell_farm</span><span class="special">()</span> <span class="special">);</span>
 
-    <span class=identifier>BOOST_ASSERT</span><span class=special>(</span> <span class=identifier>new_farm</span><span class=special>.</span><span class=identifier>size</span><span class=special>()</span>    <span class=special>==</span> <span class=number>0u</span> <span class=special>);</span>
-    <span class=identifier>BOOST_ASSERT</span><span class=special>(</span> <span class=identifier>animal_farm</span><span class=special>.</span><span class=identifier>size</span><span class=special>()</span> <span class=special>==</span> <span class=number>12u</span> <span class=special>);</span>     
-<span class=special>}</span>
+    <span class="identifier">BOOST_ASSERT</span><span class="special">(</span> <span class="identifier">new_farm</span><span class="special">.</span><span class="identifier">size</span><span class="special">()</span>    <span class="special">==</span> <span class="number">0u</span> <span class="special">);</span>
+    <span class="identifier">BOOST_ASSERT</span><span class="special">(</span> <span class="identifier">animal_farm</span><span class="special">.</span><span class="identifier">size</span><span class="special">()</span> <span class="special">==</span> <span class="number">12u</span> <span class="special">);</span>     
+<span class="special">}</span>
 </pre>
 </body>
 


### PR DESCRIPTION
The reStructuredText files insert `<hr>` HTML elements, which are not
valid in XHTML.

The doc/tutorial_example.html file contains unquoted attributes and
unclosed `<meta>` and `<link>` tags (although since that file is included
into another document, it probably shouldn't have `<html>`, `<head>` and
`<body>` elements at all).
